### PR TITLE
Loop status reading countdown

### DIFF
--- a/LoopFollow/Controllers/NightScout.swift
+++ b/LoopFollow/Controllers/NightScout.swift
@@ -616,13 +616,15 @@ extension MainViewController {
                                 latestLoopStatusString = "⏀"
                                 if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "Open Loop: recommended temp. temp time > bg time, was not enacted") }
                             } else {
-                                LoopStatusLabel.text = "↻"
+                                //Auggie - adding rough time since loop for closer tracking on the main screen
+                                LoopStatusLabel.text = String(format: "%.0f%", (TimeInterval(Date().timeIntervalSince1970) - lastLoopTime) / 60) + "m  ↻"
                                 latestLoopStatusString = "↻"
                                 if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "Looping: recommended temp, but temp time is < bg time and/or was enacted") }
                             }
                         }
                     } else {
-                        LoopStatusLabel.text = "↻"
+                        //Auggie adding rough time since loop for closer tracking on the main screen
+                        LoopStatusLabel.text = String(format: "%.0f%", (TimeInterval(Date().timeIntervalSince1970) - lastLoopTime) / 60) + "m  ↻"
                         latestLoopStatusString = "↻"
                         if UserDefaultsRepository.debugLog.value { self.writeDebugLog(value: "Looping: no recommended temp") }
                     }

--- a/LoopFollow/Controllers/Timers.swift
+++ b/LoopFollow/Controllers/Timers.swift
@@ -44,6 +44,7 @@ extension MainViewController {
     }
     
     // Updates Min Ago display
+    //Auggie - I like to see the seconds all the time
     @objc func minAgoTimerDidEnd(_ timer:Timer) {
         
         // print("min ago timer ended")
@@ -56,24 +57,19 @@ extension MainViewController {
             let formatter = DateComponentsFormatter()
             formatter.unitsStyle = .positional // Use the appropriate positioning for the current locale
             
-            if secondsAgo < 270 {
-                formatter.allowedUnits = [ .minute] // Units to display in the formatted string
-            } else {
-                formatter.allowedUnits = [ .minute, .second] // Units to display in the formatted string
-            }
-            
+            formatter.allowedUnits = [ .minute, .second] // Units to display in the formatted string
             
             //formatter.zeroFormattingBehavior = [ .pad ] // Pad with zeroes where appropriate for the locale
             let formattedDuration = formatter.string(from: secondsAgo)
             
             MinAgoText.text = formattedDuration ?? ""
-            MinAgoText.text! += " min ago"
+            MinAgoText.text! += " ago"
             latestMinAgoString = formattedDuration ?? ""
-            latestMinAgoString += " min ago"
+            latestMinAgoString += " ago"
             
             if let snoozer = self.tabBarController!.viewControllers?[2] as? SnoozeViewController {
                 snoozer.MinAgoLabel.text = formattedDuration ?? ""
-                snoozer.MinAgoLabel.text! += " min ago"
+                snoozer.MinAgoLabel.text! += " ago"
             } else { return }
             
         } else {


### PR DESCRIPTION
Two things:
1. Show rough time since last the loop status on the main screen for a bit more info
2. Include seconds in the time since last reading on all screens all the time (not just after 4m have passed) - more info is helpful when we live in 5 minute cycles