### PR TITLE
Stop auto-scrolling to the right in the graph on new BGs

### DIFF
--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -543,9 +543,6 @@ extension MainViewController {
             BGChart.zoom(scaleX: scaleX, scaleY: 1, x: 1, y: 1)
             firstGraphLoad = false
         }
-        
-        // Move to current reading everytime new readings load
-        BGChart.moveViewToAnimated(xValue: dateTimeUtils.getNowTimeIntervalUTC() - (BGChart.visibleXRange * 0.7), yValue: 0.0, axis: .right, duration: 1, easingOption: .easeInBack)
     }
     
     func updatePredictionGraph(color: UIColor? = nil) {


### PR DESCRIPTION
Stop auto-scrolling to the right in the graph every time a new BG comes in - helpful for viewing history and not losing place when a new reading comes in