### PR TITLE
Fix SwiftFormat lint errors across Watch and Widget targets

### DIFF
--- a/LoopFollow/Watch/PhoneSessionManager.swift
+++ b/LoopFollow/Watch/PhoneSessionManager.swift
@@ -8,7 +8,7 @@ import WatchConnectivity
 class PhoneSessionManager: NSObject, WCSessionDelegate {
     static let shared = PhoneSessionManager()
 
-    private override init() {
+    override private init() {
         super.init()
     }
 
@@ -71,15 +71,15 @@ class PhoneSessionManager: NSObject, WCSessionDelegate {
 
     // MARK: - WCSessionDelegate
 
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+    func session(_: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error _: Error?) {
         if activationState == .activated {
             sendConfig()
         }
     }
 
-    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidBecomeInactive(_: WCSession) {}
 
-    func sessionDidDeactivate(_ session: WCSession) {
+    func sessionDidDeactivate(_: WCSession) {
         WCSession.default.activate()
     }
 
@@ -91,14 +91,14 @@ class PhoneSessionManager: NSObject, WCSessionDelegate {
     }
 
     // Handle Watch requesting config via applicationContext
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+    func session(_: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
         if applicationContext["requestConfig"] != nil {
             sendConfig()
         }
     }
 
     // Handle Watch requesting config via sendMessage (with reply)
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+    func session(_: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
         if message["requestConfig"] != nil {
             let config = buildConfig()
             replyHandler(config)
@@ -109,14 +109,14 @@ class PhoneSessionManager: NSObject, WCSessionDelegate {
         }
     }
 
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+    func session(_: WCSession, didReceiveMessage message: [String: Any]) {
         if message["requestConfig"] != nil {
             sendConfig()
         }
     }
 
     // Handle Watch requesting config via transferUserInfo
-    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
+    func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
         if userInfo["requestConfig"] != nil {
             sendConfig()
         }

--- a/LoopFollowWatch/BGChartView.swift
+++ b/LoopFollowWatch/BGChartView.swift
@@ -25,6 +25,7 @@ struct BGChartView: View {
         default: return 6
         }
     }
+
     private var treatmentSymbolSize: CGFloat { CGFloat(30.0 * min(1.6, max(0.7, 2.0 / zoomHours))) }
     private var showTreatmentLabels: Bool { treatmentLevel >= 2 }
     @FocusState private var chartFocused: Bool
@@ -317,7 +318,7 @@ struct BGChartView: View {
                 let pts = screenPoints.map(\.point)
                 guard pts.count >= 2 else { return }
 
-                for i in 0..<(pts.count - 1) {
+                for i in 0 ..< (pts.count - 1) {
                     let midBG = Double(screenPoints[i].bgValue + screenPoints[i + 1].bgValue) / 2.0
                     let segColor = bgDynamicColor(midBG)
 

--- a/LoopFollowWatch/BGDynamicColor.swift
+++ b/LoopFollowWatch/BGDynamicColor.swift
@@ -1,9 +1,5 @@
 // LoopFollow
 // BGDynamicColor.swift
-//
-// Maps a BG value (mg/dL) to a hue-based color.
-// Red (hue 0°) at ≤55, Green (hue 120°) at 100, Purple (hue 270°) at ≥220.
-// Interpolates linearly through the hue spectrum between those anchors.
 
 import SwiftUI
 

--- a/LoopFollowWatch/BGFetcher.swift
+++ b/LoopFollowWatch/BGFetcher.swift
@@ -8,7 +8,7 @@ import WidgetKit
 // MARK: - Widget Data (shared with LoopFollowWidgets target via UserDefaults)
 
 struct WidgetBGPoint: Codable, Hashable {
-    let value: Int      // mg/dL
+    let value: Int // mg/dL
     let timestamp: Date
 }
 
@@ -40,7 +40,7 @@ struct WidgetData: Codable {
     }
 
     static func load() -> WidgetData? {
-        guard let data = sharedDefaults.data(forKey: Self.storageKey),
+        guard let data = sharedDefaults.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode(WidgetData.self, from: data)
         else { return nil }
         return decoded
@@ -128,6 +128,7 @@ class BGFetcher: ObservableObject {
     private let dexcomApplicationId = "d89443d2-327c-4a6f-89e5-496bbb0317db"
 
     // MARK: - Adaptive fetch cadence
+
     //
     // CGM readings arrive every ~5 min. Rather than fetching on a fixed 5-min
     // repeating timer (which ends up phase-locked to whenever start() was
@@ -422,7 +423,8 @@ class BGFetcher: ObservableObject {
         // Pump / uploader info live as siblings of `loop` on the devicestatus entry.
         let battery: Int? = {
             if let uploader = entry["uploader"] as? [String: Any],
-               let b = uploader["battery"] as? Double {
+               let b = uploader["battery"] as? Double
+            {
                 return Int(b)
             }
             return nil
@@ -445,25 +447,29 @@ class BGFetcher: ObservableObject {
 
         // IOB
         if let iobData = loopRecord["iob"] as? [String: Any],
-           let iobValue = iobData["iob"] as? Double {
+           let iobValue = iobData["iob"] as? Double
+        {
             iob = iobValue
         }
 
         // COB
         if let cobData = loopRecord["cob"] as? [String: Any],
-           let cobValue = cobData["cob"] as? Double {
+           let cobValue = cobData["cob"] as? Double
+        {
             cob = cobValue
         }
 
         // Basal
         if let enacted = loopRecord["enacted"] as? [String: Any],
-           let rate = enacted["rate"] as? Double {
+           let rate = enacted["rate"] as? Double
+        {
             basalRate = rate
         }
 
         // Predictions
         if let predictData = loopRecord["predicted"] as? [String: Any],
-           let values = predictData["values"] as? [Double] {
+           let values = predictData["values"] as? [Double]
+        {
             predictions = values
             predictionStart = timestamp
         }
@@ -475,7 +481,8 @@ class BGFetcher: ObservableObject {
 
         // Override (top-level in devicestatus for Loop)
         if let overrideData = entry["override"] as? [String: Any],
-           let isActive = overrideData["active"] as? Bool, isActive {
+           let isActive = overrideData["active"] as? Bool, isActive
+        {
             overrideActive = true
             var oText = ""
             if let multiplier = overrideData["multiplier"] as? Double {
@@ -485,7 +492,8 @@ class BGFetcher: ObservableObject {
             }
             if let correction = overrideData["currentCorrectionRange"] as? [String: Any],
                let minVal = correction["minValue"] as? Double,
-               let maxVal = correction["maxValue"] as? Double {
+               let maxVal = correction["maxValue"] as? Double
+            {
                 oText += " (\(Int(minVal))-\(Int(maxVal)))"
             }
             overrideText = oText
@@ -533,7 +541,8 @@ class BGFetcher: ObservableObject {
         // Pump / uploader info live as siblings of `openaps` on the devicestatus entry.
         let battery: Int? = {
             if let uploader = entry["uploader"] as? [String: Any],
-               let b = uploader["battery"] as? Double {
+               let b = uploader["battery"] as? Double
+            {
                 return Int(b)
             }
             return nil
@@ -561,7 +570,8 @@ class BGFetcher: ObservableObject {
 
         // IOB
         if let iobData = openapsRecord["iob"] as? [String: Any],
-           let iobValue = iobData["iob"] as? Double {
+           let iobValue = iobData["iob"] as? Double
+        {
             iob = iobValue
         }
 
@@ -571,7 +581,8 @@ class BGFetcher: ObservableObject {
         } else if let reason = enactedOrSuggested?["reason"] as? String {
             let pattern = "COB: (\\d+(?:\\.\\d+)?)"
             if let regex = try? NSRegularExpression(pattern: pattern),
-               let match = regex.firstMatch(in: reason, range: NSRange(location: 0, length: reason.utf16.count)) {
+               let match = regex.firstMatch(in: reason, range: NSRange(location: 0, length: reason.utf16.count))
+            {
                 let valueString = (reason as NSString).substring(with: match.range(at: 1))
                 cob = Double(valueString)
             }
@@ -583,7 +594,8 @@ class BGFetcher: ObservableObject {
         if let reason = enactedOrSuggested?["reason"] as? String {
             let crPattern = "CR: (\\d+(?:\\.\\d+)?)"
             if let regex = try? NSRegularExpression(pattern: crPattern),
-               let match = regex.firstMatch(in: reason, range: NSRange(location: 0, length: reason.utf16.count)) {
+               let match = regex.firstMatch(in: reason, range: NSRange(location: 0, length: reason.utf16.count))
+            {
                 let valueString = (reason as NSString).substring(with: match.range(at: 1))
                 carbRatio = Double(valueString)
             }
@@ -591,17 +603,20 @@ class BGFetcher: ObservableObject {
 
         // Basal from enacted
         if let enacted = openapsRecord["enacted"] as? [String: Any],
-           let rate = enacted["rate"] as? Double {
+           let rate = enacted["rate"] as? Double
+        {
             basalRate = rate
         }
 
         // Predictions - all four types
         let predBGsData: [String: Any]? = {
             if let suggested = openapsRecord["suggested"] as? [String: Any],
-               let predBGs = suggested["predBGs"] as? [String: Any] {
+               let predBGs = suggested["predBGs"] as? [String: Any]
+            {
                 return predBGs
             } else if let enacted = openapsRecord["enacted"] as? [String: Any],
-                      let predBGs = enacted["predBGs"] as? [String: Any] {
+                      let predBGs = enacted["predBGs"] as? [String: Any]
+            {
                 return predBGs
             }
             return nil
@@ -631,7 +646,8 @@ class BGFetcher: ObservableObject {
         if tdd == nil, let reason = reasonText {
             let pattern = "TDD:\\s*(\\d+(?:\\.\\d+)?)"
             if let regex = try? NSRegularExpression(pattern: pattern),
-               let match = regex.firstMatch(in: reason, range: NSRange(location: 0, length: reason.utf16.count)) {
+               let match = regex.firstMatch(in: reason, range: NSRange(location: 0, length: reason.utf16.count))
+            {
                 let valueString = (reason as NSString).substring(with: match.range(at: 1))
                 tdd = Double(valueString)
             }
@@ -644,7 +660,8 @@ class BGFetcher: ObservableObject {
         if let enacted = openapsRecord["enacted"] as? [String: Any],
            let targetBG = enacted["target_bg"] as? Double,
            let currentTarget = enactedOrSuggested?["current_target"] as? Double,
-           targetBG != currentTarget {
+           targetBG != currentTarget
+        {
             tempTargetActive = true
             tempTargetText = "\(Int(targetBG)) mg/dL"
         }
@@ -915,7 +932,8 @@ class BGFetcher: ObservableObject {
 
         // Extract timezone
         if let tz = defaultStore?["timezone"] as? String,
-           let timezone = TimeZone(identifier: tz) {
+           let timezone = TimeZone(identifier: tz)
+        {
             newTimezone = timezone
         }
 
@@ -944,7 +962,8 @@ class BGFetcher: ObservableObject {
 
         // Loop overrides from loopSettings
         if let loopSettings = profile["loopSettings"] as? [String: Any],
-           let overridePresetsArray = loopSettings["overridePresets"] as? [[String: Any]] {
+           let overridePresetsArray = loopSettings["overridePresets"] as? [[String: Any]]
+        {
             for preset in overridePresetsArray {
                 guard let name = preset["name"] as? String else { continue }
                 let duration = preset["duration"] as? Double
@@ -957,7 +976,8 @@ class BGFetcher: ObservableObject {
         // Also check loopSettings inside default store
         if presets.isEmpty,
            let storeLoopSettings = defaultStore?["loopSettings"] as? [String: Any],
-           let overridePresetsArray = storeLoopSettings["overridePresets"] as? [[String: Any]] {
+           let overridePresetsArray = storeLoopSettings["overridePresets"] as? [[String: Any]]
+        {
             for preset in overridePresetsArray {
                 guard let name = preset["name"] as? String else { continue }
                 let duration = preset["duration"] as? Double
@@ -1053,7 +1073,8 @@ class BGFetcher: ObservableObject {
             switch eventType {
             case "Pump Site Change", "Site Change":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
-                   let ts = parseNSDate(dateStr) {
+                   let ts = parseNSDate(dateStr)
+                {
                     if newCannulaChangeDate == nil || ts > newCannulaChangeDate! {
                         newCannulaChangeDate = ts
                     }
@@ -1061,7 +1082,8 @@ class BGFetcher: ObservableObject {
 
             case "Sensor Start", "Sensor Change":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
-                   let ts = parseNSDate(dateStr) {
+                   let ts = parseNSDate(dateStr)
+                {
                     if newSensorChangeDate == nil || ts > newSensorChangeDate! {
                         newSensorChangeDate = ts
                     }
@@ -1069,7 +1091,8 @@ class BGFetcher: ObservableObject {
 
             case "Insulin Change", "Insulin Cartridge Change":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
-                   let ts = parseNSDate(dateStr) {
+                   let ts = parseNSDate(dateStr)
+                {
                     if newInsulinChangeDate == nil || ts > newInsulinChangeDate! {
                         newInsulinChangeDate = ts
                     }
@@ -1077,7 +1100,8 @@ class BGFetcher: ObservableObject {
 
             case "Correction Bolus", "Bolus", "External Insulin":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
-                   let ts = parseNSDate(dateStr) {
+                   let ts = parseNSDate(dateStr)
+                {
                     if let automatic = entry["automatic"] as? Bool, automatic {
                         if let insulin = entry["insulin"] as? Double, insulin > 0 {
                             newTreatments.append(Treatment(timestamp: ts, type: .smb, value: insulin))
@@ -1092,13 +1116,15 @@ class BGFetcher: ObservableObject {
             case "SMB":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
                    let ts = parseNSDate(dateStr),
-                   let insulin = entry["insulin"] as? Double, insulin > 0 {
+                   let insulin = entry["insulin"] as? Double, insulin > 0
+                {
                     newTreatments.append(Treatment(timestamp: ts, type: .smb, value: insulin))
                 }
 
             case "Meal Bolus":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
-                   let ts = parseNSDate(dateStr) {
+                   let ts = parseNSDate(dateStr)
+                {
                     if let insulin = entry["insulin"] as? Double, insulin > 0 {
                         newTreatments.append(Treatment(timestamp: ts, type: .bolus, value: insulin))
                     }
@@ -1110,7 +1136,8 @@ class BGFetcher: ObservableObject {
             case "Carb Correction":
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
                    let ts = parseNSDate(dateStr),
-                   let carbs = entry["carbs"] as? Double, carbs > 0 {
+                   let carbs = entry["carbs"] as? Double, carbs > 0
+                {
                     newTreatments.append(Treatment(timestamp: ts, type: .carbs, value: carbs))
                 }
 
@@ -1126,7 +1153,8 @@ class BGFetcher: ObservableObject {
             default:
                 // Generic bolus/carb fallback
                 if let dateStr = entry["timestamp"] as? String ?? entry["created_at"] as? String,
-                   let ts = parseNSDate(dateStr) {
+                   let ts = parseNSDate(dateStr)
+                {
                     if let insulin = entry["insulin"] as? Double, insulin > 0 {
                         newTreatments.append(Treatment(timestamp: ts, type: .bolus, value: insulin))
                     }
@@ -1208,7 +1236,8 @@ class BGFetcher: ObservableObject {
             // Cap at next override start to prevent overlap
             if i + 1 < sortedOverrides.count,
                let nextDateStr = sortedOverrides[i + 1]["timestamp"] as? String ?? sortedOverrides[i + 1]["created_at"] as? String,
-               let nextStart = parseNSDate(nextDateStr) {
+               let nextStart = parseNSDate(nextDateStr)
+            {
                 if endDate > nextStart.addingTimeInterval(-60) {
                     endDate = nextStart.addingTimeInterval(-60)
                 }
@@ -1415,7 +1444,7 @@ class BGFetcher: ObservableObject {
         }
 
         guard !readings.isEmpty else {
-            self.fallbackToNightscout(config: config, dexError: "No Dexcom readings")
+            fallbackToNightscout(config: config, dexError: "No Dexcom readings")
             return
         }
 

--- a/LoopFollowWatch/CelebrationOverlay.swift
+++ b/LoopFollowWatch/CelebrationOverlay.swift
@@ -63,7 +63,7 @@ struct CelebrationOverlay: View {
 
     /// Returns true roughly every 5–15 sends (≈10% chance per send).
     static func shouldCelebrate() -> Bool {
-        return Int.random(in: 1...10) == 1
+        return Int.random(in: 1 ... 10) == 1
     }
 
     /// How long to show the celebration before dismissing (longer than normal 3s).
@@ -89,26 +89,26 @@ struct CelebrationOverlay: View {
         switch animationType {
         case .confetti:
             // Two waves of confetti covering the full screen
-            let wave1: [Particle] = (0..<40).map { _ in
+            let wave1: [Particle] = (0 ..< 40).map { _ in
                 Particle(
                     x: 0, y: -20,
-                    targetX: Double.random(in: -120...120),
-                    targetY: Double.random(in: 60...220),
-                    size: Double.random(in: 5...10),
-                    rotation: Double.random(in: 360...1080),
-                    delay: Double.random(in: 0...0.5),
+                    targetX: Double.random(in: -120 ... 120),
+                    targetY: Double.random(in: 60 ... 220),
+                    size: Double.random(in: 5 ... 10),
+                    rotation: Double.random(in: 360 ... 1080),
+                    delay: Double.random(in: 0 ... 0.5),
                     color: [.red, .blue, .green, .yellow, .orange, .pink, .purple, .mint, .cyan].randomElement()!,
                     emoji: "", wave: 1
                 )
             }
-            let wave2: [Particle] = (0..<25).map { _ in
+            let wave2: [Particle] = (0 ..< 25).map { _ in
                 Particle(
-                    x: Double.random(in: -60...60), y: -40,
-                    targetX: Double.random(in: -120...120),
-                    targetY: Double.random(in: 40...200),
-                    size: Double.random(in: 6...12),
-                    rotation: Double.random(in: 360...1080),
-                    delay: Double.random(in: 0...0.4),
+                    x: Double.random(in: -60 ... 60), y: -40,
+                    targetX: Double.random(in: -120 ... 120),
+                    targetY: Double.random(in: 40 ... 200),
+                    size: Double.random(in: 6 ... 12),
+                    rotation: Double.random(in: 360 ... 1080),
+                    delay: Double.random(in: 0 ... 0.4),
                     color: [.red, .blue, .green, .yellow, .orange, .pink, .purple, .mint, .cyan].randomElement()!,
                     emoji: "", wave: 2
                 )
@@ -120,19 +120,19 @@ struct CelebrationOverlay: View {
             var all: [Particle] = []
             let bursts: [(Double, Double, Double)] = [
                 (0, -30, 0), (-40, -50, 0.3), (35, -20, 0.7),
-                (-20, 10, 1.5), (30, -45, 1.8), (0, 0, 2.2)
+                (-20, 10, 1.5), (30, -45, 1.8), (0, 0, 2.2),
             ]
             for (bx, by, baseDelay) in bursts {
-                for _ in 0..<12 {
-                    let angle = Double.random(in: 0...(2 * .pi))
-                    let dist = Double.random(in: 30...90)
+                for _ in 0 ..< 12 {
+                    let angle = Double.random(in: 0 ... (2 * .pi))
+                    let dist = Double.random(in: 30 ... 90)
                     all.append(Particle(
                         x: bx, y: by,
                         targetX: bx + cos(angle) * dist,
                         targetY: by + sin(angle) * dist,
-                        size: Double.random(in: 4...8),
+                        size: Double.random(in: 4 ... 8),
                         rotation: 0,
-                        delay: baseDelay + Double.random(in: 0...0.15),
+                        delay: baseDelay + Double.random(in: 0 ... 0.15),
                         color: [.red, .orange, .yellow, .cyan, .white, .pink, .green].randomElement()!,
                         emoji: "", wave: baseDelay < 1.0 ? 1 : 2
                     ))
@@ -142,16 +142,16 @@ struct CelebrationOverlay: View {
 
         case .sparkleRain:
             // Dense sparkles falling across the full width, two waves
-            particles = (0..<30).map { i in
+            particles = (0 ..< 30).map { i in
                 let wave = i < 18 ? 1 : 2
                 return Particle(
-                    x: Double.random(in: -100...100),
+                    x: Double.random(in: -100 ... 100),
                     y: -120,
-                    targetX: Double.random(in: -100...100),
+                    targetX: Double.random(in: -100 ... 100),
                     targetY: 160,
-                    size: Double.random(in: 12...22),
-                    rotation: Double.random(in: -360...360),
-                    delay: Double.random(in: 0...(wave == 1 ? 1.5 : 0.8)),
+                    size: Double.random(in: 12 ... 22),
+                    rotation: Double.random(in: -360 ... 360),
+                    delay: Double.random(in: 0 ... (wave == 1 ? 1.5 : 0.8)),
                     color: [.yellow, .white, .orange, .cyan, .mint].randomElement()!,
                     emoji: "", wave: wave
                 )
@@ -183,45 +183,45 @@ struct CelebrationOverlay: View {
         case .partyEmoji:
             // Huge emoji bouncing in from all edges, two waves
             let emojis = ["🎉", "🥳", "🎊", "🪩", "✨", "💫", "⭐️", "🌟", "🎆", "🎇", "🍾", "🥂"]
-            let wave1: [Particle] = (0..<6).map { _ in
-                let edge = Int.random(in: 0...3)
+            let wave1: [Particle] = (0 ..< 6).map { _ in
+                let edge = Int.random(in: 0 ... 3)
                 let startX: Double
                 let startY: Double
                 switch edge {
-                case 0: startX = Double.random(in: -100...100); startY = -140
-                case 1: startX = Double.random(in: -100...100); startY = 140
-                case 2: startX = -140; startY = Double.random(in: -80...80)
-                default: startX = 140; startY = Double.random(in: -80...80)
+                case 0: startX = Double.random(in: -100 ... 100); startY = -140
+                case 1: startX = Double.random(in: -100 ... 100); startY = 140
+                case 2: startX = -140; startY = Double.random(in: -80 ... 80)
+                default: startX = 140; startY = Double.random(in: -80 ... 80)
                 }
                 return Particle(
                     x: startX, y: startY,
-                    targetX: Double.random(in: -50...50),
-                    targetY: Double.random(in: -50...50),
-                    size: Double.random(in: 40...56),
-                    rotation: Double.random(in: -30...30),
-                    delay: Double.random(in: 0...0.6),
+                    targetX: Double.random(in: -50 ... 50),
+                    targetY: Double.random(in: -50 ... 50),
+                    size: Double.random(in: 40 ... 56),
+                    rotation: Double.random(in: -30 ... 30),
+                    delay: Double.random(in: 0 ... 0.6),
                     color: .white,
                     emoji: emojis.randomElement()!,
                     wave: 1
                 )
             }
-            let wave2: [Particle] = (0..<5).map { _ in
-                let edge = Int.random(in: 0...3)
+            let wave2: [Particle] = (0 ..< 5).map { _ in
+                let edge = Int.random(in: 0 ... 3)
                 let startX: Double
                 let startY: Double
                 switch edge {
-                case 0: startX = Double.random(in: -100...100); startY = -140
-                case 1: startX = Double.random(in: -100...100); startY = 140
-                case 2: startX = -140; startY = Double.random(in: -80...80)
-                default: startX = 140; startY = Double.random(in: -80...80)
+                case 0: startX = Double.random(in: -100 ... 100); startY = -140
+                case 1: startX = Double.random(in: -100 ... 100); startY = 140
+                case 2: startX = -140; startY = Double.random(in: -80 ... 80)
+                default: startX = 140; startY = Double.random(in: -80 ... 80)
                 }
                 return Particle(
                     x: startX, y: startY,
-                    targetX: Double.random(in: -50...50),
-                    targetY: Double.random(in: -50...50),
-                    size: Double.random(in: 44...60),
-                    rotation: Double.random(in: -30...30),
-                    delay: Double.random(in: 0...0.5),
+                    targetX: Double.random(in: -50 ... 50),
+                    targetY: Double.random(in: -50 ... 50),
+                    size: Double.random(in: 44 ... 60),
+                    rotation: Double.random(in: -30 ... 30),
+                    delay: Double.random(in: 0 ... 0.5),
                     color: .white,
                     emoji: emojis.randomElement()!,
                     wave: 2

--- a/LoopFollowWatch/ContentView.swift
+++ b/LoopFollowWatch/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
     @ObservedObject var bgFetcher: BGFetcher
 
     @State private var now = Date()
-    @State private var timeOffset: Double = 7.2  // zoomHours(2) * 3.6 — aligns marker with "now"
+    @State private var timeOffset: Double = 7.2 // zoomHours(2) * 3.6 — aligns marker with "now"
     @State private var zoomHours: Double = 2
     @State private var showReloadCheck = false
     @State private var showLoopDetail = false
@@ -100,6 +100,7 @@ struct ContentView: View {
     private var visibleStart: Date {
         Date().addingTimeInterval(-zoomHours * 3600 + timeOffset.rounded() * 300)
     }
+
     private var visibleEnd: Date {
         Date().addingTimeInterval(timeOffset.rounded() * 300)
     }
@@ -112,7 +113,8 @@ struct ContentView: View {
         guard visible.count >= 2,
               let first = visible.first?.timestamp,
               let last = visible.last?.timestamp,
-              last > first else {
+              last > first
+        else {
             // Fall back to single color from current reading
             if let reading = visible.first ?? bgHistory.last {
                 return LinearGradient(colors: [bgDynamicColor(Double(reading.bgValue)).opacity(0.4)], startPoint: .leading, endPoint: .trailing)
@@ -233,7 +235,7 @@ struct ContentView: View {
                                     .init(color: .clear, location: 0),
                                     .init(color: .white, location: 0.06),
                                     .init(color: .white, location: 0.94),
-                                    .init(color: .clear, location: 1.0)
+                                    .init(color: .clear, location: 1.0),
                                 ],
                                 startPoint: .leading,
                                 endPoint: .trailing
@@ -245,7 +247,7 @@ struct ContentView: View {
                                     .init(color: .white.opacity(0.3), location: 0),
                                     .init(color: .white, location: 0.45),
                                     .init(color: .white, location: 0.55),
-                                    .init(color: .white.opacity(0.3), location: 1.0)
+                                    .init(color: .white.opacity(0.3), location: 1.0),
                                 ],
                                 startPoint: .top,
                                 endPoint: .bottom
@@ -362,7 +364,8 @@ struct ContentView: View {
     private func freshnessText(reading: BGReading) -> String {
         // When not showing the latest reading, display the clock time
         if let latest = bgFetcher.currentBG,
-           reading.timestamp != latest.timestamp {
+           reading.timestamp != latest.timestamp
+        {
             let formatter = DateFormatter()
             formatter.dateFormat = "h:mm a"
             return formatter.string(from: reading.timestamp)

--- a/LoopFollowWatch/FollowStatusView.swift
+++ b/LoopFollowWatch/FollowStatusView.swift
@@ -1,11 +1,5 @@
 // LoopFollow
 // FollowStatusView.swift
-//
-// Full-screen sheet shown when the user taps the loop-status icon. Two tabs:
-// "Device Status" mirrors the iPhone "Follow Status" view (LOOP / OVERRIDE /
-// REASON / PUMP / SITE / TODAY / UPDATED), and "Profile" lists the active
-// profile schedules. All data is sourced from BGFetcher state already
-// downloaded for the main view — no new fetches.
 
 import SwiftUI
 
@@ -163,7 +157,8 @@ private struct DeviceStatusTab: View {
     private var overrideSection: some View {
         let s = bgFetcher.loopStatus
         if (s?.overrideActive == true && s?.overrideText != nil)
-            || (s?.tempTargetActive == true && s?.tempTargetText != nil) {
+            || (s?.tempTargetActive == true && s?.tempTargetText != nil)
+        {
             VStack(alignment: .leading, spacing: 4) {
                 SectionHeader("Override")
                 if let oText = s?.overrideText, s?.overrideActive == true {

--- a/LoopFollowWatch/LoopFollowWatchApp.swift
+++ b/LoopFollowWatch/LoopFollowWatchApp.swift
@@ -7,7 +7,6 @@ import WatchKit
 import WidgetKit
 
 class ExtensionDelegate: NSObject, WKApplicationDelegate, UNUserNotificationCenterDelegate {
-
     func applicationDidFinishLaunching() {
         WatchSessionManager.shared.startSession()
         let center = UNUserNotificationCenter.current()
@@ -32,7 +31,8 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate, UNUserNotificationCent
                 // regardless of whether the app was cold-launched by the
                 // system or brought to the foreground by the user.
                 if let config = WatchSessionManager.shared.config,
-                   config.hasAnySource {
+                   config.hasAnySource
+                {
                     BGFetcher.shared.fetch(config: config)
                     // Give the network requests a few seconds to land, then complete.
                     DispatchQueue.main.asyncAfter(deadline: .now() + 12) {
@@ -80,8 +80,8 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate, UNUserNotificationCent
 
     // Show notifications even when the app is in the foreground
     func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
+        _: UNUserNotificationCenter,
+        willPresent _: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         completionHandler([.banner, .sound])

--- a/LoopFollowWatch/LoopStatus.swift
+++ b/LoopFollowWatch/LoopStatus.swift
@@ -25,17 +25,17 @@ struct LoopStatus {
     let tempTargetText: String?
 
     // Bolus calculation values from devicestatus
-    let recommendedBolus: Double?   // Loop only — direct from devicestatus
-    let isf: Double?                // OpenAPS — enacted/suggested ISF (autosens-adjusted)
-    let carbRatio: Double?          // OpenAPS — from reason string
-    let currentTarget: Double?      // OpenAPS — enacted/suggested current_target
+    let recommendedBolus: Double? // Loop only — direct from devicestatus
+    let isf: Double? // OpenAPS — enacted/suggested ISF (autosens-adjusted)
+    let carbRatio: Double? // OpenAPS — from reason string
+    let currentTarget: Double? // OpenAPS — enacted/suggested current_target
 
     // Extended OpenAPS/Trio fields surfaced in the Follow Status sheet
-    let autosensRatio: Double?      // OpenAPS — sensitivityRatio (1.00 == 100%)
-    let eventualBG: Double?         // OpenAPS — eventualBG
-    let tdd: Double?                // OpenAPS — TDD (units)
-    let minPredBG: Double?          // OpenAPS — min across all predBGs.* arrays
-    let maxPredBG: Double?          // OpenAPS — max across all predBGs.* arrays
-    let insulinReq: Double?         // OpenAPS — insulinReq
-    let reason: String?             // OpenAPS/Loop — full reason free-text
+    let autosensRatio: Double? // OpenAPS — sensitivityRatio (1.00 == 100%)
+    let eventualBG: Double? // OpenAPS — eventualBG
+    let tdd: Double? // OpenAPS — TDD (units)
+    let minPredBG: Double? // OpenAPS — min across all predBGs.* arrays
+    let maxPredBG: Double? // OpenAPS — max across all predBGs.* arrays
+    let insulinReq: Double? // OpenAPS — insulinReq
+    let reason: String? // OpenAPS/Loop — full reason free-text
 }

--- a/LoopFollowWatch/NavigationRouter.swift
+++ b/LoopFollowWatch/NavigationRouter.swift
@@ -1,8 +1,5 @@
 // LoopFollow
 // NavigationRouter.swift
-//
-// Handles deep link URL parsing and drives programmatic navigation
-// from complication shortcuts into the watch app's screens.
 
 import SwiftUI
 
@@ -27,9 +24,9 @@ class NavigationRouter: ObservableObject {
         activeDestination = nil
 
         switch url.host {
-        case "bolus":      navigateTo(.bolus)
-        case "meal":       navigateTo(.meal)
-        case "override":   navigateTo(.override)
+        case "bolus": navigateTo(.bolus)
+        case "meal": navigateTo(.meal)
+        case "override": navigateTo(.override)
         case "temptarget": navigateTo(.tempTarget)
         default:
             // "open" or unknown — stay on main graph (tab 0)

--- a/LoopFollowWatch/StatsView.swift
+++ b/LoopFollowWatch/StatsView.swift
@@ -1,18 +1,5 @@
 // LoopFollow
 // StatsView.swift
-//
-// Third watch page (swipe right from Remote). Mirrors the iPhone
-// LoopFollow stats block: pie chart for Low / In Range / High
-// distribution, plus Avg BG, Est A1C, and Std Dev. Computed over the
-// last 24 hours of the bgHistory cache that BGFetcher already holds
-// for the chart (~300 readings ≈ 25h from Nightscout or Dexcom Share).
-//
-// Formulas match LoopFollow/Controllers/Stats.swift exactly:
-//   - Low/High thresholds are inclusive (<= lowLine, >= highLine)
-//   - Population standard deviation (divide by N, not N-1)
-//   - NGSP A1C: (avgBG + 46.7) / 28.7
-// IFCC A1C and per-user alt formulas live on the iPhone via
-// Storage.useIFCC; we default to NGSP here to keep WatchConfig small.
 
 import Charts
 import SwiftUI
@@ -231,9 +218,9 @@ struct StatsResult {
     let percentLow: Double
     let percentRange: Double
     let percentHigh: Double
-    let avgBG: Double   // always mg/dL; convert at display time
-    let stdDev: Double  // always mg/dL; convert at display time
-    let a1c: Double     // percent (NGSP)
+    let avgBG: Double // always mg/dL; convert at display time
+    let stdDev: Double // always mg/dL; convert at display time
+    let a1c: Double // percent (NGSP)
 }
 
 enum StatsCompute {

--- a/LoopFollowWatch/WatchMealView.swift
+++ b/LoopFollowWatch/WatchMealView.swift
@@ -54,12 +54,12 @@ struct WatchMealView: View {
     }
 
     private var crownRange: ClosedRange<Double> {
-        guard let field = editingField else { return 0...1 }
+        guard let field = editingField else { return 0 ... 1 }
         switch field {
-        case .carbs: return 0...config.maxCarbs
-        case .protein: return 0...config.maxProtein
-        case .fat: return 0...config.maxFat
-        case .time: return -240...240
+        case .carbs: return 0 ... config.maxCarbs
+        case .protein: return 0 ... config.maxProtein
+        case .fat: return 0 ... config.maxFat
+        case .time: return -240 ... 240
         }
     }
 

--- a/LoopFollowWatch/WatchOverrideView.swift
+++ b/LoopFollowWatch/WatchOverrideView.swift
@@ -29,97 +29,97 @@ struct WatchOverrideView: View {
                     CelebrationOverlay(isActive: $showCelebration)
                 }
             } else {
-        ScrollView {
-            VStack(spacing: 6) {
-                if showConfirm, let override = selectedOverride {
-                    Text(override.name)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.purple)
+                ScrollView {
+                    VStack(spacing: 6) {
+                        if showConfirm, let override = selectedOverride {
+                            Text(override.name)
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(.purple)
 
-                    if let pct = override.percentage {
-                        Text(String(format: "%.0f%%", pct))
-                            .font(.system(size: 12))
-                            .foregroundColor(.secondary)
-                    }
-
-                    CrownConfirmView(label: "to activate") {
-                        sendOverride(name: override.name)
-                    }
-                } else if showCancelConfirm {
-                    Text("Cancel Override")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.red)
-
-                    CrownConfirmView(label: "to cancel") {
-                        cancelOverride()
-                    }
-                } else {
-                    // Active override section (check both devicestatus and treatments)
-                    if let activeOverride = activeOverrideEntry {
-                        Text("Active Override")
-                            .font(.system(size: 12))
-                            .foregroundColor(.gray)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-
-                        Text(activeOverride.name + (activeOverride.percentage.map { String(format: " %.0f%%", $0) } ?? ""))
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 10)
-                            .background(Color.purple.opacity(0.55))
-                            .cornerRadius(8)
-
-                        Button {
-                            showCancelConfirm = true
-                        } label: {
-                            Text("Cancel Override")
-                                .font(.system(size: 15, weight: .medium))
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
-                                .background(Color.red.opacity(0.3))
-                                .cornerRadius(8)
-                        }
-                        .buttonStyle(.plain)
-
-                        Divider()
-                    }
-
-                    Text("Available Overrides")
-                        .font(.system(size: 14, weight: .semibold))
-
-                    if bgFetcher.overridePresets.isEmpty {
-                        Text("No presets found.\nCheck Nightscout profile.")
-                            .font(.system(size: 12))
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                    } else {
-                        ForEach(bgFetcher.overridePresets) { preset in
-                            Button {
-                                selectedOverride = preset
-                                showConfirm = true
-                            } label: {
-                                HStack {
-                                    Text(preset.name)
-                                        .font(.system(size: 15, weight: .medium))
-                                    Spacer()
-                                    if let pct = preset.percentage {
-                                        Text(String(format: "%.0f%%", pct))
-                                            .font(.system(size: 12))
-                                            .foregroundColor(.secondary)
-                                    }
-                                }
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 14)
-                                .background(Color.purple.opacity(0.55))
-                                .cornerRadius(8)
+                            if let pct = override.percentage {
+                                Text(String(format: "%.0f%%", pct))
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.secondary)
                             }
-                            .buttonStyle(.plain)
+
+                            CrownConfirmView(label: "to activate") {
+                                sendOverride(name: override.name)
+                            }
+                        } else if showCancelConfirm {
+                            Text("Cancel Override")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(.red)
+
+                            CrownConfirmView(label: "to cancel") {
+                                cancelOverride()
+                            }
+                        } else {
+                            // Active override section (check both devicestatus and treatments)
+                            if let activeOverride = activeOverrideEntry {
+                                Text("Active Override")
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.gray)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                                Text(activeOverride.name + (activeOverride.percentage.map { String(format: " %.0f%%", $0) } ?? ""))
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 10)
+                                    .background(Color.purple.opacity(0.55))
+                                    .cornerRadius(8)
+
+                                Button {
+                                    showCancelConfirm = true
+                                } label: {
+                                    Text("Cancel Override")
+                                        .font(.system(size: 15, weight: .medium))
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 14)
+                                        .background(Color.red.opacity(0.3))
+                                        .cornerRadius(8)
+                                }
+                                .buttonStyle(.plain)
+
+                                Divider()
+                            }
+
+                            Text("Available Overrides")
+                                .font(.system(size: 14, weight: .semibold))
+
+                            if bgFetcher.overridePresets.isEmpty {
+                                Text("No presets found.\nCheck Nightscout profile.")
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.secondary)
+                                    .multilineTextAlignment(.center)
+                            } else {
+                                ForEach(bgFetcher.overridePresets) { preset in
+                                    Button {
+                                        selectedOverride = preset
+                                        showConfirm = true
+                                    } label: {
+                                        HStack {
+                                            Text(preset.name)
+                                                .font(.system(size: 15, weight: .medium))
+                                            Spacer()
+                                            if let pct = preset.percentage {
+                                                Text(String(format: "%.0f%%", pct))
+                                                    .font(.system(size: 12))
+                                                    .foregroundColor(.secondary)
+                                            }
+                                        }
+                                        .padding(.horizontal, 10)
+                                        .padding(.vertical, 14)
+                                        .background(Color.purple.opacity(0.55))
+                                        .cornerRadius(8)
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
             }
         }
     }

--- a/LoopFollowWatch/WatchRemoteService.swift
+++ b/LoopFollowWatch/WatchRemoteService.swift
@@ -7,7 +7,6 @@ import UserNotifications
 import WatchKit
 
 class WatchRemoteService {
-
     // MARK: - Local Notification Helper
 
     static func postLocalNotification(title: String, body: String) {
@@ -299,7 +298,7 @@ class WatchRemoteService {
         request.setValue(payload.commandType, forHTTPHeaderField: "apns-collapse-id")
         request.httpBody = try? JSONEncoder().encode(message)
 
-        URLSession.shared.dataTask(with: request) { data, response, error in
+        URLSession.shared.dataTask(with: request) { _, response, error in
             DispatchQueue.main.async {
                 if let error = error {
                     completion(false, error.localizedDescription)

--- a/LoopFollowWatch/WatchSessionManager.swift
+++ b/LoopFollowWatch/WatchSessionManager.swift
@@ -9,7 +9,7 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
 
     @Published var config: WatchConfig?
 
-    private override init() {
+    override private init() {
         super.init()
         // Load cached config on startup
         config = WatchConfig.loadFromDefaults()
@@ -41,7 +41,7 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
 
     // MARK: - WCSessionDelegate
 
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+    func session(_ session: WCSession, activationDidCompleteWith _: WCSessionActivationState, error: Error?) {
         if let error = error {
             print("WCSession activation failed: \(error.localizedDescription)")
             return
@@ -59,15 +59,15 @@ class WatchSessionManager: NSObject, ObservableObject, WCSessionDelegate {
         }
     }
 
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+    func session(_: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
         handleReceivedConfig(applicationContext)
     }
 
-    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
+    func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
         handleReceivedConfig(userInfo)
     }
 
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+    func session(_: WCSession, didReceiveMessage message: [String: Any]) {
         handleReceivedConfig(message)
     }
 

--- a/LoopFollowWatch/WatchTempTargetView.swift
+++ b/LoopFollowWatch/WatchTempTargetView.swift
@@ -212,10 +212,10 @@ private struct CustomTempTargetView: View {
     }
 
     private var crownRange: ClosedRange<Double> {
-        guard !showConfirm else { return 0...1 }
+        guard !showConfirm else { return 0 ... 1 }
         switch editingField {
-        case .target: return 60...300
-        case .duration: return 5...480
+        case .target: return 60 ... 300
+        case .duration: return 5 ... 480
         }
     }
 

--- a/LoopFollowWidgets/ActionShortcutWidgets.swift
+++ b/LoopFollowWidgets/ActionShortcutWidgets.swift
@@ -1,9 +1,5 @@
 // LoopFollow
 // ActionShortcutWidgets.swift
-//
-// Four static circular complications for quick actions:
-// Bolus (drop), Meal (fork & knife), Override (lightning bolt), Temp Target (target).
-// Each deep links to the corresponding screen in the watch app.
 
 import SwiftUI
 import WidgetKit
@@ -15,15 +11,15 @@ struct ActionEntry: TimelineEntry {
 }
 
 struct ActionTimelineProvider: TimelineProvider {
-    func placeholder(in context: Context) -> ActionEntry {
+    func placeholder(in _: Context) -> ActionEntry {
         ActionEntry(date: .now)
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (ActionEntry) -> Void) {
+    func getSnapshot(in _: Context, completion: @escaping (ActionEntry) -> Void) {
         completion(ActionEntry(date: .now))
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<ActionEntry>) -> Void) {
+    func getTimeline(in _: Context, completion: @escaping (Timeline<ActionEntry>) -> Void) {
         completion(Timeline(entries: [ActionEntry(date: .now)], policy: .never))
     }
 }

--- a/LoopFollowWidgets/BGDynamicColor.swift
+++ b/LoopFollowWidgets/BGDynamicColor.swift
@@ -1,9 +1,5 @@
 // LoopFollow
 // BGDynamicColor.swift
-//
-// Maps a BG value (mg/dL) to a hue-based color.
-// Red (hue 0°) at ≤55, Green (hue 120°) at 100, Purple (hue 270°) at ≥220.
-// Interpolates linearly through the hue spectrum between those anchors.
 
 import SwiftUI
 

--- a/LoopFollowWidgets/BGLiveActivity.swift
+++ b/LoopFollowWidgets/BGLiveActivity.swift
@@ -1,111 +1,103 @@
 // LoopFollow
 // BGLiveActivity.swift
-//
-// Live Activity definition for real-time BG monitoring on the iPhone Lock Screen
-// and Dynamic Island. Uses the same BGComplicationContent view as the watch
-// complication, so the visual style is identical.
-//
-// Gated behind #if os(iOS) because ActivityKit is not available on watchOS.
-// When an iOS widget extension target is added, this file will compile and
-// BGLiveActivityWidget can be included in the widget bundle.
 
 #if os(iOS)
-import ActivityKit
-import SwiftUI
-import WidgetKit
+    import ActivityKit
+    import SwiftUI
+    import WidgetKit
 
-// MARK: - Activity Attributes
+    // MARK: - Activity Attributes
 
-struct BGLiveActivityAttributes: ActivityAttributes {
-    struct ContentState: Codable, Hashable {
-        let bgValue: Int
-        let direction: String
-        let delta: Int?
-        let bgTimestamp: Date
-        let iob: Double?
-        let cob: Double?
-        let basalRate: Double?
-        let scheduledBasal: Double?
-        let history: [WidgetBGPoint]
-        let units: String
-        let updatedAt: Date
+    struct BGLiveActivityAttributes: ActivityAttributes {
+        struct ContentState: Codable, Hashable {
+            let bgValue: Int
+            let direction: String
+            let delta: Int?
+            let bgTimestamp: Date
+            let iob: Double?
+            let cob: Double?
+            let basalRate: Double?
+            let scheduledBasal: Double?
+            let history: [WidgetBGPoint]
+            let units: String
+            let updatedAt: Date
 
-        init(from data: WidgetData) {
-            self.bgValue = data.bgValue
-            self.direction = data.direction
-            self.delta = data.delta
-            self.bgTimestamp = data.bgTimestamp
-            self.iob = data.iob
-            self.cob = data.cob
-            self.basalRate = data.basalRate
-            self.scheduledBasal = data.scheduledBasal
-            self.history = data.history
-            self.units = data.units
-            self.updatedAt = data.updatedAt
-        }
-    }
-}
-
-// MARK: - Live Activity Configuration
-
-struct BGLiveActivityWidget: Widget {
-    var body: some WidgetConfiguration {
-        ActivityConfiguration(for: BGLiveActivityAttributes.self) { context in
-            let data = widgetData(from: context.state)
-            BGComplicationContent(
-                data: data,
-                displayDate: Date(),
-                useColor: true
-            )
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .activityBackgroundTint(.black.opacity(0.7))
-
-        } dynamicIsland: { context in
-            DynamicIsland {
-                DynamicIslandExpandedRegion(.center) {
-                    let data = widgetData(from: context.state)
-                    BGComplicationContent(
-                        data: data,
-                        displayDate: Date(),
-                        useColor: true
-                    )
-                }
-            } compactLeading: {
-                Text("\(context.state.bgValue)")
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
-                    .foregroundColor(bgColor(for: context.state.bgValue))
-            } compactTrailing: {
-                Text(context.state.direction)
-                    .font(.system(size: 12))
-            } minimal: {
-                Text("\(context.state.bgValue)")
-                    .font(.system(size: 12, weight: .bold, design: .rounded))
-                    .foregroundColor(bgColor(for: context.state.bgValue))
+            init(from data: WidgetData) {
+                bgValue = data.bgValue
+                direction = data.direction
+                delta = data.delta
+                bgTimestamp = data.bgTimestamp
+                iob = data.iob
+                cob = data.cob
+                basalRate = data.basalRate
+                scheduledBasal = data.scheduledBasal
+                history = data.history
+                units = data.units
+                updatedAt = data.updatedAt
             }
         }
     }
 
-    private func widgetData(from state: BGLiveActivityAttributes.ContentState) -> WidgetData {
-        WidgetData(
-            bgValue: state.bgValue,
-            direction: state.direction,
-            delta: state.delta,
-            bgTimestamp: state.bgTimestamp,
-            iob: state.iob,
-            cob: state.cob,
-            basalRate: state.basalRate,
-            scheduledBasal: state.scheduledBasal,
-            history: state.history,
-            units: state.units,
-            updatedAt: state.updatedAt
-        )
-    }
+    // MARK: - Live Activity Configuration
 
-    private func bgColor(for bg: Int) -> Color {
-        if bg < 70 || bg > 180 { return .red }
-        if bg < 80 || bg > 170 { return .yellow }
-        return .green
+    struct BGLiveActivityWidget: Widget {
+        var body: some WidgetConfiguration {
+            ActivityConfiguration(for: BGLiveActivityAttributes.self) { context in
+                let data = widgetData(from: context.state)
+                BGComplicationContent(
+                    data: data,
+                    displayDate: Date(),
+                    useColor: true
+                )
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .activityBackgroundTint(.black.opacity(0.7))
+
+            } dynamicIsland: { context in
+                DynamicIsland {
+                    DynamicIslandExpandedRegion(.center) {
+                        let data = widgetData(from: context.state)
+                        BGComplicationContent(
+                            data: data,
+                            displayDate: Date(),
+                            useColor: true
+                        )
+                    }
+                } compactLeading: {
+                    Text("\(context.state.bgValue)")
+                        .font(.system(size: 14, weight: .bold, design: .rounded))
+                        .foregroundColor(bgColor(for: context.state.bgValue))
+                } compactTrailing: {
+                    Text(context.state.direction)
+                        .font(.system(size: 12))
+                } minimal: {
+                    Text("\(context.state.bgValue)")
+                        .font(.system(size: 12, weight: .bold, design: .rounded))
+                        .foregroundColor(bgColor(for: context.state.bgValue))
+                }
+            }
+        }
+
+        private func widgetData(from state: BGLiveActivityAttributes.ContentState) -> WidgetData {
+            WidgetData(
+                bgValue: state.bgValue,
+                direction: state.direction,
+                delta: state.delta,
+                bgTimestamp: state.bgTimestamp,
+                iob: state.iob,
+                cob: state.cob,
+                basalRate: state.basalRate,
+                scheduledBasal: state.scheduledBasal,
+                history: state.history,
+                units: state.units,
+                updatedAt: state.updatedAt
+            )
+        }
+
+        private func bgColor(for bg: Int) -> Color {
+            if bg < 70 || bg > 180 { return .red }
+            if bg < 80 || bg > 170 { return .yellow }
+            return .green
+        }
     }
-}
 #endif

--- a/LoopFollowWidgets/BGTimelineProvider.swift
+++ b/LoopFollowWidgets/BGTimelineProvider.swift
@@ -1,30 +1,8 @@
 // LoopFollow
 // BGTimelineProvider.swift
-//
-// Aggressive refresh strategy for near-real-time BG complication updates:
-//
-// 1. MULTI-ENTRY TIMELINE: Generate 60 entries (one per minute for 1 hour) from a
-//    single data snapshot. Each entry has its own `date` so WidgetKit displays
-//    them at the correct time — the staleness counter advances naturally without
-//    needing a reload. These cost zero budget; only timeline *reloads* count.
-//
-// 2. APP-DRIVEN RELOADS: BGFetcher calls WidgetCenter.shared.reloadAllTimelines()
-//    every time new BG data arrives (~every 5 min while foregrounded). Each reload
-//    generates a fresh batch of 12 entries.
-//
-// 3. BACKGROUND APP REFRESH: The watch app schedules WKApplicationRefreshBackgroundTask
-//    every ~15 min. When it fires, the app fetches new data from Nightscout/Dexcom
-//    and reloads timelines — even when the app isn't on screen.
-//
-// 4. TIMELINE RELOAD POLICY: .after(next) requests the system reload in 5 minutes.
-//    Combined with the pre-generated entries, the complication always has something
-//    fresh to display even if the budget is exhausted for a while.
-//
-// Net effect: complication updates every ~5 min in practice, with worst-case ~15 min
-// from background refresh, matching or exceeding apps like SweetDreams.
 
-import WidgetKit
 import SwiftUI
+import WidgetKit
 
 struct BGEntry: TimelineEntry {
     let date: Date
@@ -35,19 +13,18 @@ struct BGEntry: TimelineEntry {
 }
 
 struct BGTimelineProvider: TimelineProvider {
-
     // MARK: - Required protocol
 
-    func placeholder(in context: Context) -> BGEntry {
+    func placeholder(in _: Context) -> BGEntry {
         BGEntry(date: .now, data: nil, displayDate: .now)
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (BGEntry) -> Void) {
+    func getSnapshot(in _: Context, completion: @escaping (BGEntry) -> Void) {
         let entry = BGEntry(date: .now, data: WidgetData.load(), displayDate: .now)
         completion(entry)
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<BGEntry>) -> Void) {
+    func getTimeline(in _: Context, completion: @escaping (Timeline<BGEntry>) -> Void) {
         // Try to fetch fresh BG directly from Nightscout. This runs inside
         // the widget extension process — independent of the watch app and its
         // background task budget. The system calls getTimeline every ~5 min
@@ -55,9 +32,9 @@ struct BGTimelineProvider: TimelineProvider {
         WidgetNightscoutFetcher.fetch { result in
             let data: WidgetData?
             switch result {
-            case .updated(let d):  data = d
-            case .unchanged(let d): data = d
-            case .failed(let d):   data = d
+            case let .updated(d): data = d
+            case let .unchanged(d): data = d
+            case let .failed(d): data = d
             }
 
             let now = Date()
@@ -66,7 +43,7 @@ struct BGTimelineProvider: TimelineProvider {
             // Each entry carries a different `displayDate` so the staleness text
             // advances correctly without burning a reload.
             var entries: [BGEntry] = []
-            for i in 0..<60 {
+            for i in 0 ..< 60 {
                 let entryDate = now.addingTimeInterval(Double(i) * 60)
                 entries.append(BGEntry(date: entryDate, data: data, displayDate: entryDate))
             }

--- a/LoopFollowWidgets/CircularComplicationView.swift
+++ b/LoopFollowWidgets/CircularComplicationView.swift
@@ -1,5 +1,6 @@
 // LoopFollow
 // CircularComplicationView.swift
+
 //
 // Round complication for modular watch faces (accessoryCircular).
 // Layout: staleness on top, BG center, delta + trend below.

--- a/LoopFollowWidgets/LoopFollowWidgets.swift
+++ b/LoopFollowWidgets/LoopFollowWidgets.swift
@@ -1,8 +1,8 @@
 // LoopFollow
 // LoopFollowWidgets.swift
 
-import WidgetKit
 import SwiftUI
+import WidgetKit
 
 struct BGComplicationEntryView: View {
     let entry: BGEntry
@@ -44,7 +44,7 @@ struct LoopFollowWidgetBundle: WidgetBundle {
         OverrideShortcutWidget()
         TempTargetShortcutWidget()
         #if os(iOS)
-        BGLiveActivityWidget()
+            BGLiveActivityWidget()
         #endif
     }
 }

--- a/LoopFollowWidgets/RectangularComplicationView.swift
+++ b/LoopFollowWidgets/RectangularComplicationView.swift
@@ -1,9 +1,5 @@
 // LoopFollow
 // RectangularComplicationView.swift
-//
-// Reusable BG display view for both accessoryRectangular complication and
-// future Live Activity usage. Text overlays left side, sparkline fades in
-// from left to right with progressive line thickness. No background color.
 
 import SwiftUI
 import WidgetKit
@@ -29,7 +25,7 @@ struct BGComplicationContent: View {
                     stops: [
                         .init(color: .clear, location: 0),
                         .init(color: .clear, location: 0.39),
-                        .init(color: .white, location: 0.80)
+                        .init(color: .white, location: 0.80),
                     ],
                     startPoint: .leading,
                     endPoint: .trailing
@@ -120,8 +116,8 @@ private struct SparklineView: View {
         GeometryReader { geo in
             let w = geo.size.width
             let h = geo.size.height
-            let topInset: CGFloat = 6     // room for top y-axis label
-            let bottomInset: CGFloat = 4  // room for bottom y-axis label
+            let topInset: CGFloat = 6 // room for top y-axis label
+            let bottomInset: CGFloat = 4 // room for bottom y-axis label
             let chartH = h - topInset - bottomInset
             // Keep sparkline clear of y-axis labels. Labels sit at
             // x = w - 16 in a 28pt trailing-aligned frame, so a
@@ -170,30 +166,30 @@ private struct SparklineView: View {
                 if screenPoints.count >= 2 {
                     Group {
                         // Per-segment fill + stroke — each colored by midpoint BG value
-                        ForEach(0..<(screenPoints.count - 1), id: \.self) { i in
-                        let t = Double(i) / Double(max(screenPoints.count - 2, 1))
-                        let lineWidth = 0.3 + t * 1.7
-                        let opacity = min(t * 1.4, 1.0)
-                        let midBG = Double(sorted[i].value + sorted[i + 1].value) / 2.0
-                        let segColor = bgDynamicColor(midBG)
+                        ForEach(0 ..< (screenPoints.count - 1), id: \.self) { i in
+                            let t = Double(i) / Double(max(screenPoints.count - 2, 1))
+                            let lineWidth = 0.3 + t * 1.7
+                            let opacity = min(t * 1.4, 1.0)
+                            let midBG = Double(sorted[i].value + sorted[i + 1].value) / 2.0
+                            let segColor = bgDynamicColor(midBG)
 
-                        // Fill slice under this segment
-                        buildSegmentFill(points: screenPoints, index: i, height: topInset + chartH)
-                            .fill(
-                                LinearGradient(
-                                    colors: [segColor.opacity(0.60), segColor.opacity(0.05)],
-                                    startPoint: .top,
-                                    endPoint: .bottom
+                            // Fill slice under this segment
+                            buildSegmentFill(points: screenPoints, index: i, height: topInset + chartH)
+                                .fill(
+                                    LinearGradient(
+                                        colors: [segColor.opacity(0.60), segColor.opacity(0.05)],
+                                        startPoint: .top,
+                                        endPoint: .bottom
+                                    )
                                 )
-                            )
 
-                        // Stroke with progressive width + opacity
-                        buildSingleSegment(points: screenPoints, index: i)
-                            .stroke(
-                                segColor.opacity(opacity),
-                                style: StrokeStyle(lineWidth: lineWidth, lineCap: .butt, lineJoin: .round)
-                            )
-                    }
+                            // Stroke with progressive width + opacity
+                            buildSingleSegment(points: screenPoints, index: i)
+                                .stroke(
+                                    segColor.opacity(opacity),
+                                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .butt, lineJoin: .round)
+                                )
+                        }
                     }
                     .widgetAccentable()
                 }
@@ -261,7 +257,7 @@ private struct SparklineView: View {
             if points.count == 2 {
                 path.addLine(to: last)
             } else {
-                for i in 0..<(points.count - 1) {
+                for i in 0 ..< (points.count - 1) {
                     let p0 = points[max(i - 1, 0)]
                     let p1 = points[i]
                     let p2 = points[min(i + 1, points.count - 1)]

--- a/LoopFollowWidgets/WidgetData.swift
+++ b/LoopFollowWidgets/WidgetData.swift
@@ -1,26 +1,25 @@
 // LoopFollow
 // WidgetData.swift
-// Shared data model between the watch app and widget extension.
 
 import Foundation
 
 struct WidgetBGPoint: Codable, Hashable {
-    let value: Int      // mg/dL
+    let value: Int // mg/dL
     let timestamp: Date
 }
 
 struct WidgetData: Codable {
-    let bgValue: Int        // current BG in mg/dL
-    let direction: String   // trend arrow
-    let delta: Int?         // signed delta from previous reading
-    let bgTimestamp: Date   // when the current BG was recorded
+    let bgValue: Int // current BG in mg/dL
+    let direction: String // trend arrow
+    let delta: Int? // signed delta from previous reading
+    let bgTimestamp: Date // when the current BG was recorded
     let iob: Double?
     let cob: Double?
-    let basalRate: Double?      // current enacted rate
+    let basalRate: Double? // current enacted rate
     let scheduledBasal: Double? // profile-based rate
     let history: [WidgetBGPoint] // last ~3 hours
-    let units: String       // "mg/dL" or "mmol/L"
-    let updatedAt: Date     // when this snapshot was written
+    let units: String // "mg/dL" or "mmol/L"
+    let updatedAt: Date // when this snapshot was written
 
     private static let storageKey = "widgetData"
 
@@ -38,7 +37,7 @@ struct WidgetData: Codable {
     }
 
     static func load() -> WidgetData? {
-        guard let data = sharedDefaults.data(forKey: Self.storageKey),
+        guard let data = sharedDefaults.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode(WidgetData.self, from: data)
         else { return nil }
         return decoded

--- a/LoopFollowWidgets/WidgetNightscoutFetcher.swift
+++ b/LoopFollowWidgets/WidgetNightscoutFetcher.swift
@@ -1,21 +1,14 @@
 // LoopFollow
 // WidgetNightscoutFetcher.swift
-//
-// Lightweight Nightscout BG fetcher for the widget extension. Fetches only the
-// 3 most recent entries (count=3) and merges any new readings into the cached
-// WidgetData. This runs inside getTimeline(), which the system calls every ~5
-// minutes for an active complication — giving us a reliable update path that
-// doesn't depend on the watch app's background task budget.
 
 import Foundation
 
 enum WidgetNightscoutFetcher {
-
     /// Result of a widget-side fetch attempt.
     enum FetchResult {
-        case updated(WidgetData)   // new reading(s) merged into cache
+        case updated(WidgetData) // new reading(s) merged into cache
         case unchanged(WidgetData) // cache was already current
-        case failed(WidgetData?)   // network/parse error; returns cache if available
+        case failed(WidgetData?) // network/parse error; returns cache if available
     }
 
     /// Fetch the latest 3 entries from Nightscout, merge into cached WidgetData,
@@ -72,7 +65,7 @@ enum WidgetNightscoutFetcher {
         var sgv: Double?
         var mbg: Double?
         var glucose: Double?
-        var date: TimeInterval    // epoch millis
+        var date: TimeInterval // epoch millis
         var direction: String?
 
         var bgValue: Int? {
@@ -91,7 +84,7 @@ enum WidgetNightscoutFetcher {
         "DoubleUp": "↑↑", "SingleUp": "↑", "FortyFiveUp": "↗",
         "Flat": "→", "FortyFiveDown": "↘", "SingleDown": "↓",
         "DoubleDown": "↓↓", "NOT COMPUTABLE": "-", "RATE OUT OF RANGE": "-",
-        "NONE": "-", "": "-"
+        "NONE": "-", "": "-",
     ]
 
     private static func mergeResponse(data: Data) -> FetchResult {
@@ -99,7 +92,8 @@ enum WidgetNightscoutFetcher {
 
         guard let entries = try? JSONDecoder().decode([NSEntry].self, from: data),
               let latest = entries.first,
-              let latestBG = latest.bgValue else {
+              let latestBG = latest.bgValue
+        else {
             return .failed(cache)
         }
 


### PR DESCRIPTION
- Apply SwiftFormat auto-fixes to resolve CI lint failures
- Changes include indentation, file headers, spacing around operators, unused argument markers, brace wrapping, trailing commas, sort imports, and redundant self removal
- Covers ~25 files in LoopFollowWatch, LoopFollowWidgets, and LoopFollow/Watch.