### PR TITLE
Resolve a prior missed commit for missing added carbs

### DIFF
--- a/LoopFollowWatch/WatchMealView.swift
+++ b/LoopFollowWatch/WatchMealView.swift
@@ -134,9 +134,6 @@ struct WatchMealView: View {
                 bgFetcher.updateRecommendedBolus()
             }
         }
-        .onDisappear {
-            bgFetcher.pendingCarbs = 0
-        }
     }
 
     private let gridColumns = [


### PR DESCRIPTION
- COB could under report by not including freshly entered COB in meal entry flow during bolus screen