### PR TITLE
Add Trio smoothed BG display option

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -64,6 +64,9 @@
 		65E153C32E4BB69100693A4F /* URLTokenValidationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E153C22E4BB69100693A4F /* URLTokenValidationView.swift */; };
 		65E8A2862E44B0300065037B /* VolumeButtonHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E8A2852E44B0300065037B /* VolumeButtonHandler.swift */; };
 		66E3D12E66AA4534A144A54B /* BackgroundRefreshManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CA8BE0B3D247408FE088B4 /* BackgroundRefreshManager.swift */; };
+		9C7FB98C98BE4FF98F4815EE /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFBE69CEF18416D84959974 /* Telemetry.swift */; };
+		A1A1A10001000000A0CFEED1 /* APNsCredentialValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A10001000000A0CFEED2 /* APNsCredentialValidator.swift */; };
+		A1A1A10002000000A0CFEED1 /* LogRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A10002000000A0CFEED2 /* LogRedactor.swift */; };
 		ACE7F6DE0D065BEB52CDC0DB /* FutureCarbsAlarmEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D2A4EFD18B7B7748B6669E /* FutureCarbsAlarmEditor.swift */; };
 		DD0247592DB2E89600FCADF6 /* AlarmCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0247582DB2E89600FCADF6 /* AlarmCondition.swift */; };
 		DD0247712DB4337700FCADF6 /* BuildExpireCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD02475B2DB2E8FB00FCADF6 /* BuildExpireCondition.swift */; };
@@ -250,7 +253,6 @@
 		DDD10F0B2C54192A00D76A8E /* TemporaryTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD10F0A2C54192A00D76A8E /* TemporaryTarget.swift */; };
 		DDDB86F12DF7223C00AADDAC /* DeleteAlarmSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDB86F02DF7223C00AADDAC /* DeleteAlarmSection.swift */; };
 		DDDC01DD2E244B3100D9975C /* JWTManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDC01DC2E244B3100D9975C /* JWTManager.swift */; };
-		A1A1A10002000000A0CFEED1 /* LogRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A10002000000A0CFEED2 /* LogRedactor.swift */; };
 		DDDC31CC2E13A7DF009EA0F3 /* AddAlarmSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDC31CB2E13A7DF009EA0F3 /* AddAlarmSheet.swift */; };
 		DDDC31CE2E13A811009EA0F3 /* AlarmTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDC31CD2E13A811009EA0F3 /* AlarmTile.swift */; };
 		DDDF6F492D479AF000884336 /* NoRemoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDF6F482D479AEF00884336 /* NoRemoteView.swift */; };
@@ -267,6 +269,7 @@
 		DDEF50422D479BAA00884336 /* LoopAPNSCarbsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEF50412D479BAA00884336 /* LoopAPNSCarbsView.swift */; };
 		DDEF50432D479BBA00884336 /* LoopAPNSBolusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEF50422D479BBA00884336 /* LoopAPNSBolusView.swift */; };
 		DDEF50452D479BDA00884336 /* LoopAPNSRemoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEF50442D479BDA00884336 /* LoopAPNSRemoteView.swift */; };
+		DDF1A0010000000000000002 /* SmoothedBgHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF1A0010000000000000001 /* SmoothedBgHistory.swift */; };
 		DDF2C0102BEFA991007A20E6 /* GitHubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF2C00F2BEFA991007A20E6 /* GitHubService.swift */; };
 		DDF2C0122BEFB733007A20E6 /* AppVersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF2C0112BEFB733007A20E6 /* AppVersionManager.swift */; };
 		DDF2C0142BEFD468007A20E6 /* blacklisted-versions.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF2C0132BEFD468007A20E6 /* blacklisted-versions.json */; };
@@ -291,7 +294,6 @@
 		FC1BDD3224A2585C001B652C /* DataStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC1BDD2E24A232A3001B652C /* DataStructs.swift */; };
 		FC3AE7B5249E8E0E00AAE1E0 /* LoopFollow.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FC3AE7B3249E8E0E00AAE1E0 /* LoopFollow.xcdatamodeld */; };
 		FC3CAB022493B6220068A152 /* BackgroundTaskAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC688592489554800A0279D /* BackgroundTaskAudio.swift */; };
-		A1A1A10001000000A0CFEED1 /* APNsCredentialValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A10001000000A0CFEED2 /* APNsCredentialValidator.swift */; };
 		FC5A5C3D2497B229009C550E /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = FC5A5C3C2497B229009C550E /* Config.xcconfig */; };
 		FC7CE518248ABE37001F83B8 /* Siri_Alert_Calibration_Needed.caf in Resources */ = {isa = PBXBuildFile; fileRef = FC7CE4A9248ABE2B001F83B8 /* Siri_Alert_Calibration_Needed.caf */; };
 		FC7CE519248ABE37001F83B8 /* Rise_And_Shine.caf in Resources */ = {isa = PBXBuildFile; fileRef = FC7CE4AA248ABE2B001F83B8 /* Rise_And_Shine.caf */; };
@@ -424,7 +426,6 @@
 		FCC6886B24898FD800A0279D /* ObservationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC6886A24898FD800A0279D /* ObservationToken.swift */; };
 		FCC6886D2489909D00A0279D /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC6886C2489909D00A0279D /* AnyConvertible.swift */; };
 		FCC6886F2489A53800A0279D /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC6886E2489A53800A0279D /* AppConstants.swift */; };
-		9C7FB98C98BE4FF98F4815EE /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFBE69CEF18416D84959974 /* Telemetry.swift */; };
 		FCD2A27D24C9D044009F7B7B /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD2A27C24C9D044009F7B7B /* Globals.swift */; };
 		FCE537BC249A4D7D00F80BF8 /* carbBolusArrays.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCE537BB249A4D7D00F80BF8 /* carbBolusArrays.swift */; };
 		FCEF87AC24A141A700AE6FA0 /* Localizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEF87AA24A1417900AE6FA0 /* Localizer.swift */; };
@@ -517,9 +518,12 @@
 		65A100022F5AA00000AA1002 /* UnitsConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitsConfigurationView.swift; sourceTree = "<group>"; };
 		65E153C22E4BB69100693A4F /* URLTokenValidationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLTokenValidationView.swift; sourceTree = "<group>"; };
 		65E8A2852E44B0300065037B /* VolumeButtonHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeButtonHandler.swift; sourceTree = "<group>"; };
+		A1A1A10001000000A0CFEED2 /* APNsCredentialValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsCredentialValidator.swift; sourceTree = "<group>"; };
+		A1A1A10002000000A0CFEED2 /* LogRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactor.swift; sourceTree = "<group>"; };
 		A7D55B42A22051DAD69E89D0 /* Pods_LoopFollow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LoopFollow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A8CA8BE0B3D247408FE088B4 /* BackgroundRefreshManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshManager.swift; sourceTree = "<group>"; };
 		B7D2A4EFD18B7B7748B6669E /* FutureCarbsAlarmEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FutureCarbsAlarmEditor.swift; sourceTree = "<group>"; };
+		BDFBE69CEF18416D84959974 /* Telemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		DD0247582DB2E89600FCADF6 /* AlarmCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmCondition.swift; sourceTree = "<group>"; };
 		DD02475B2DB2E8FB00FCADF6 /* BuildExpireCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildExpireCondition.swift; sourceTree = "<group>"; };
 		DD026E582EA2C8A200A39CB5 /* InsulinPrecisionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsulinPrecisionManager.swift; sourceTree = "<group>"; };
@@ -707,7 +711,6 @@
 		DDD10F0A2C54192A00D76A8E /* TemporaryTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryTarget.swift; sourceTree = "<group>"; };
 		DDDB86F02DF7223C00AADDAC /* DeleteAlarmSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAlarmSection.swift; sourceTree = "<group>"; };
 		DDDC01DC2E244B3100D9975C /* JWTManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTManager.swift; sourceTree = "<group>"; };
-		A1A1A10002000000A0CFEED2 /* LogRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRedactor.swift; sourceTree = "<group>"; };
 		DDDC31CB2E13A7DF009EA0F3 /* AddAlarmSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAlarmSheet.swift; sourceTree = "<group>"; };
 		DDDC31CD2E13A811009EA0F3 /* AlarmTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmTile.swift; sourceTree = "<group>"; };
 		DDDF6F482D479AEF00884336 /* NoRemoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoRemoteView.swift; sourceTree = "<group>"; };
@@ -724,6 +727,7 @@
 		DDEF50412D479BAA00884336 /* LoopAPNSCarbsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopAPNSCarbsView.swift; sourceTree = "<group>"; };
 		DDEF50422D479BBA00884336 /* LoopAPNSBolusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopAPNSBolusView.swift; sourceTree = "<group>"; };
 		DDEF50442D479BDA00884336 /* LoopAPNSRemoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopAPNSRemoteView.swift; sourceTree = "<group>"; };
+		DDF1A0010000000000000001 /* SmoothedBgHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmoothedBgHistory.swift; sourceTree = "<group>"; };
 		DDF2C00F2BEFA991007A20E6 /* GitHubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubService.swift; sourceTree = "<group>"; };
 		DDF2C0112BEFB733007A20E6 /* AppVersionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionManager.swift; sourceTree = "<group>"; };
 		DDF2C0132BEFD468007A20E6 /* blacklisted-versions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blacklisted-versions.json"; sourceTree = "<group>"; };
@@ -876,7 +880,6 @@
 		FCA2DDE52501095000254A8C /* Timers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timers.swift; sourceTree = "<group>"; };
 		FCC0FAC124922A22003E610E /* DictionaryKeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyPath.swift; sourceTree = "<group>"; };
 		FCC688592489554800A0279D /* BackgroundTaskAudio.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundTaskAudio.swift; sourceTree = "<group>"; };
-		A1A1A10001000000A0CFEED2 /* APNsCredentialValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNsCredentialValidator.swift; sourceTree = "<group>"; };
 		FCC6885B2489559400A0279D /* blank.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = blank.wav; sourceTree = "<group>"; };
 		FCC6885D24896A6C00A0279D /* silence.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = silence.mp3; sourceTree = "<group>"; };
 		FCC6886624898F8000A0279D /* UserDefaultsValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsValue.swift; sourceTree = "<group>"; };
@@ -884,7 +887,6 @@
 		FCC6886A24898FD800A0279D /* ObservationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationToken.swift; sourceTree = "<group>"; };
 		FCC6886C2489909D00A0279D /* AnyConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyConvertible.swift; sourceTree = "<group>"; };
 		FCC6886E2489A53800A0279D /* AppConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
-		BDFBE69CEF18416D84959974 /* Telemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
 		FCC688702489A57C00A0279D /* Loop Follow.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Loop Follow.entitlements"; sourceTree = "<group>"; };
 		FCD2A27C24C9D044009F7B7B /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
 		FCE537BB249A4D7D00F80BF8 /* carbBolusArrays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = carbBolusArrays.swift; sourceTree = "<group>"; };
@@ -1165,6 +1167,7 @@
 				DD493AE62ACF23CF009A6922 /* DeviceStatus.swift */,
 				DD493AE82ACF2445009A6922 /* BGData.swift */,
 				DD6A935D2BFA6FA2003FFB8E /* DeviceStatusOpenAPS.swift */,
+				DDF1A0010000000000000001 /* SmoothedBgHistory.swift */,
 				DD608A072C1F584900F91132 /* DeviceStatusLoop.swift */,
 				DD0C0C5F2C415B9D00DBADDF /* ProfileManager.swift */,
 				DD0C0C612C4175FD00DBADDF /* NSProfile.swift */,
@@ -2292,6 +2295,7 @@
 				DDAD162F2D2EF9830084BE10 /* RileyLinkHeartbeatBluetoothDevice.swift in Sources */,
 				FC97881C2485969B00A7906C /* MainViewController.swift in Sources */,
 				DD6A935E2BFA6FA2003FFB8E /* DeviceStatusOpenAPS.swift in Sources */,
+				DDF1A0010000000000000002 /* SmoothedBgHistory.swift in Sources */,
 				DD493AD52ACF2109009A6922 /* ResumePump.swift in Sources */,
 				DD85E9952D739CFE001C8BB7 /* OmnipodDashHeartbeatBluetoothTransmitter.swift in Sources */,
 				DD8316442DE47CA9004467AA /* BGPicker.swift in Sources */,
@@ -2445,7 +2449,7 @@
 				CODE_SIGN_ENTITLEMENTS = LoopFollowLAExtensionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -2497,7 +2501,7 @@
 				CODE_SIGN_ENTITLEMENTS = LoopFollowLAExtensionExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -2546,7 +2550,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2579,7 +2583,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2731,7 +2735,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LoopFollow/Loop Follow.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LoopFollow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2756,7 +2760,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LoopFollow/Loop Follow.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "$(LF_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LoopFollow/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -27,6 +27,7 @@ enum GraphDataIndex: Int {
     case smb = 16
     case tempTarget = 17
     case predictionCone = 18
+    case smoothedBg = 19
 }
 
 extension GraphDataIndex {
@@ -51,6 +52,7 @@ extension GraphDataIndex {
         case .smb: return "SMB"
         case .tempTarget: return "Temp Target"
         case .predictionCone: return "Prediction Cone"
+        case .smoothedBg: return "Smoothed BG"
         }
     }
 }
@@ -622,6 +624,20 @@ extension MainViewController {
         lineCone.axisDependency = YAxis.AxisDependency.right
         data.append(lineCone)
 
+        // Dataset 19: Smoothed BG line — light-grey straight segments connecting
+        // Trio's smoothed values, no dots. Populated only when displaySmoothedBG
+        // is on. Linear mode (passes through each value Trio reported, no curve
+        // interpolation).
+        let lineSmoothedBg = LineChartDataSet(entries: [ChartDataEntry](), label: "")
+        lineSmoothedBg.setColor(NSUIColor.lightGray)
+        lineSmoothedBg.lineWidth = 1.5
+        lineSmoothedBg.drawCirclesEnabled = false
+        lineSmoothedBg.drawValuesEnabled = false
+        lineSmoothedBg.highlightEnabled = false
+        lineSmoothedBg.axisDependency = YAxis.AxisDependency.right
+        lineSmoothedBg.mode = .linear
+        data.append(lineSmoothedBg)
+
         data.setValueFont(UIFont.systemFont(ofSize: 12))
 
         // Add marker popups for bolus and carbs
@@ -772,20 +788,17 @@ extension MainViewController {
         let dataIndexPrediction = 1
         let lineBG = BGChart.lineData!.dataSets[dataIndex] as! LineChartDataSet
         let linePrediction = BGChart.lineData!.dataSets[dataIndexPrediction] as! LineChartDataSet
-        if Storage.shared.showLines.value {
-            lineBG.lineWidth = 2
-            linePrediction.lineWidth = 2
-        } else {
+        // When smoothing is on, BG renders dots-only (the white smoothing line replaces
+        // the BG connecting line). The user-controlled toggles only apply when off.
+        if Storage.shared.displaySmoothedBG.value {
             lineBG.lineWidth = 0
-            linePrediction.lineWidth = 0
-        }
-        if Storage.shared.showDots.value {
             lineBG.drawCirclesEnabled = true
-            linePrediction.drawCirclesEnabled = true
         } else {
-            lineBG.drawCirclesEnabled = false
-            linePrediction.drawCirclesEnabled = false
+            lineBG.lineWidth = Storage.shared.showLines.value ? 2 : 0
+            lineBG.drawCirclesEnabled = Storage.shared.showDots.value
         }
+        linePrediction.lineWidth = Storage.shared.showLines.value ? 2 : 0
+        linePrediction.drawCirclesEnabled = Storage.shared.showDots.value
 
         BGChart.rightAxis.axisMinimum = 0
 
@@ -833,6 +846,7 @@ extension MainViewController {
 
         topBG = Storage.shared.minBGScale.value
         let thresholds = graphRangeThresholds()
+        let showSmoothed = Storage.shared.displaySmoothedBG.value
         for i in 0 ..< entries.count {
             // Clamp the plotted y-value to the same bounds the header text uses
             // (HIGH/LOW), so the graph stays consistent with the main display.
@@ -841,7 +855,15 @@ extension MainViewController {
             if plottedSgv > topBG - maxBGOffset {
                 topBG = plottedSgv + maxBGOffset
             }
-            let value = ChartDataEntry(x: Double(entries[i].date), y: plottedSgv, data: formatPillText(line1: Localizer.toDisplayUnits(String(entries[i].sgv)), time: entries[i].date))
+            let cgmLine = Localizer.toDisplayUnits(String(entries[i].sgv))
+            // When the smoothed BG is available, render it ABOVE the raw CGM line.
+            let pillText: String
+            if showSmoothed, let smoothed = smoothedBg(near: entries[i].date) {
+                pillText = formatPillText(line1: "✨ \(Localizer.toDisplayUnits(String(smoothed))) ✨", time: entries[i].date, line2: cgmLine)
+            } else {
+                pillText = formatPillText(line1: cgmLine, time: entries[i].date)
+            }
+            let value = ChartDataEntry(x: Double(entries[i].date), y: plottedSgv, data: pillText)
             mainChart.append(value)
             smallChart.append(value)
 
@@ -872,13 +894,54 @@ extension MainViewController {
             }
         }
 
+        // When smoothing is on, force the main BG dataset to render dots-only (no
+        // connecting line) so the smoothing line is the only line drawn through
+        // the readings. When off, honor the user's Display Lines/Dots toggles.
+        // The small chart keeps its original line-only style (set at creation in
+        // createSmallBGGraph) so we don't touch lineBGSmall here.
+        if showSmoothed {
+            lineBG.lineWidth = 0
+            lineBG.drawCirclesEnabled = true
+        } else {
+            lineBG.lineWidth = Storage.shared.showLines.value ? 2 : 0
+            lineBG.drawCirclesEnabled = Storage.shared.showDots.value
+        }
+
+        // Populate the smoothed-BG line dataset on the main chart only.
+        // We iterate `smoothedBgData` directly so the line always extends to the
+        // most recent smoothed value Trio has reported. To avoid the line being
+        // pulled toward bolus / carb dots (Trio writes extra openaps records on
+        // every treatment-triggered loop run, with timestamps that can land
+        // between the regular 5-minute cycles), we skip any record that lands
+        // within 4 minutes of the previously kept one. Regular runs are ~5 min
+        // apart so they pass through; treatment-triggered runs that fire shortly
+        // after a regular one are filtered out.
+        let smoothedIndex = GraphDataIndex.smoothedBg.rawValue
+        if let mainSmoothed = BGChart.lineData?.dataSets[smoothedIndex] as? LineChartDataSet {
+            mainSmoothed.removeAll(keepingCapacity: false)
+            if showSmoothed, !smoothedBgData.isEmpty {
+                let firstBgTime = entries.first?.date ?? -.infinity
+                let lastBgTime = entries.last?.date ?? .infinity
+                let minSpacing: TimeInterval = 240
+                var lastKeptTime: TimeInterval = -.infinity
+                for sb in smoothedBgData where sb.time >= firstBgTime && sb.time <= lastBgTime + 150 {
+                    if sb.time - lastKeptTime < minSpacing { continue }
+                    let plotted = min(max(sb.bgMgdl, Double(globalVariables.minDisplayGlucose)), Double(globalVariables.maxDisplayGlucose))
+                    mainSmoothed.append(ChartDataEntry(x: sb.time, y: plotted))
+                    lastKeptTime = sb.time
+                }
+            }
+        }
+
         BGChart.rightAxis.axisMaximum = Double(calculateMaxBgGraphValue())
         BGChart.setVisibleXRangeMinimum(600)
         BGChart.data?.dataSets[dataIndex].notifyDataSetChanged()
+        BGChart.data?.dataSets[smoothedIndex].notifyDataSetChanged()
         BGChart.data?.notifyDataChanged()
         BGChart.notifyDataSetChanged()
         BGChartFull.rightAxis.axisMaximum = Double(calculateMaxBgGraphValue())
         BGChartFull.data?.dataSets[dataIndex].notifyDataSetChanged()
+        BGChartFull.data?.dataSets[smoothedIndex].notifyDataSetChanged()
         BGChartFull.data?.notifyDataChanged()
         BGChartFull.notifyDataSetChanged()
 
@@ -1648,6 +1711,17 @@ extension MainViewController {
         lineConeSmall.highlightEnabled = false
         lineConeSmall.axisDependency = YAxis.AxisDependency.right
         data.append(lineConeSmall)
+
+        // Dataset 19: Smoothed BG line on the small graph too.
+        let lineSmoothedBgSmall = LineChartDataSet(entries: [ChartDataEntry](), label: "")
+        lineSmoothedBgSmall.setColor(NSUIColor.lightGray)
+        lineSmoothedBgSmall.lineWidth = 1.0
+        lineSmoothedBgSmall.drawCirclesEnabled = false
+        lineSmoothedBgSmall.drawValuesEnabled = false
+        lineSmoothedBgSmall.highlightEnabled = false
+        lineSmoothedBgSmall.axisDependency = YAxis.AxisDependency.right
+        lineSmoothedBgSmall.mode = .cubicBezier
+        data.append(lineSmoothedBgSmall)
 
         BGChartFull.highlightPerDragEnabled = true
         BGChartFull.leftAxis.enabled = false

--- a/LoopFollow/Controllers/Nightscout/BGData.swift
+++ b/LoopFollow/Controllers/Nightscout/BGData.swift
@@ -129,6 +129,15 @@ extension MainViewController {
 
         let latestReading = data[0]
         let sensorTimestamp = latestReading.date
+
+        // If this is a brand-new reading (newer than what we last processed), pull
+        // devicestatus right away so the smoothed BG for this dot lands on the chart
+        // alongside the dot itself, not on the next 5-min devicestatus poll.
+        let previouslyProcessedBgTime = Storage.shared.lastBgReadingTimeSeconds.value ?? 0
+        if sensorTimestamp > previouslyProcessedBgTime, IsNightscoutEnabled() {
+            // Tiny buffer so the loop has a moment to write its devicestatus record.
+            TaskScheduler.shared.rescheduleTask(id: .deviceStatus, to: Date().addingTimeInterval(1))
+        }
         let now = dateTimeUtils.getNowTimeIntervalUTC()
         // secondsAgo is how old the newest reading is
         let secondsAgo = now - sensorTimestamp

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -212,8 +212,31 @@ extension MainViewController {
         let now = dateTimeUtils.getNowTimeIntervalUTC()
         let secondsAgo = now - (Observable.shared.alertLastLoopTime.value ?? 0)
 
+        // If the smoothed-BG feature is on and the most recent BG dot doesn't yet
+        // have a matching smoothed point, poll devicestatus aggressively until it
+        // does — Trio's loop runs and writes the smoothed BG within seconds of each
+        // new CGM reading, but occasionally takes longer. Backoff the cadence:
+        // 3s while the BG is still fresh (<60s), 15s after that up to 5 minutes,
+        // then give up. Only run when we've seen at least one smoothed point
+        // (Trio is in use) so Loop accounts don't burn polls.
+        let latestBgAge: TimeInterval = bgData.last.map { Date().timeIntervalSince1970 - $0.date } ?? .infinity
+        let needsSmoothedBgRetry: Bool = {
+            guard Storage.shared.displaySmoothedBG.value,
+                  !smoothedBgData.isEmpty,
+                  let latestBg = bgData.last,
+                  latestBgAge < 300
+            else { return false }
+            return smoothedBg(near: latestBg.date) == nil
+        }()
+        let smoothedBgRetryDelay: TimeInterval = latestBgAge < 60 ? 3 : 15
+
         DispatchQueue.main.async {
-            if secondsAgo >= (20 * 60) {
+            if needsSmoothedBgRetry {
+                TaskScheduler.shared.rescheduleTask(
+                    id: .deviceStatus,
+                    to: Date().addingTimeInterval(smoothedBgRetryDelay)
+                )
+            } else if secondsAgo >= (20 * 60) {
                 TaskScheduler.shared.rescheduleTask(
                     id: .deviceStatus,
                     to: Date().addingTimeInterval(5 * 60)
@@ -250,6 +273,14 @@ extension MainViewController {
 
         // Mark device status as loaded for initial loading state
         markDataLoaded("deviceStatus")
+
+        // First successful loop run of the session: backfill the smoothed-BG history
+        // so the popup can show ✨ values for older glucose dots, not just the latest.
+        // Gated on the feature toggle and a session flag — DeviceStatusOpenAPS may
+        // have already appended the current point above, so we can't use isEmpty here.
+        if Storage.shared.displaySmoothedBG.value, !hasFetchedSmoothedBgHistory {
+            webLoadNSSmoothedBgHistory()
+        }
 
         if Storage.shared.contactEnabled.value, Storage.shared.contactIOB.value != .off,
            Observable.shared.iobText.value != previousIOBText

--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -114,6 +114,17 @@ extension MainViewController {
                 Observable.shared.deviceRecBolus.value = nil
             }
 
+            // Smoothed BG (Trio applies CGM smoothing and reports the smoothed value here).
+            // Append to in-memory history so each loop run's smoothed value can be matched to its glucose dot.
+            // Skip entirely when the feature toggle is off so we don't pay the parse / append cost.
+            if Storage.shared.displaySmoothedBG.value,
+               let smoothedBgValue = enactedOrSuggested["bg"] as? Double,
+               let updatedTime = updatedTime
+            {
+                appendSmoothedBgPoint(time: updatedTime, bgMgdl: smoothedBgValue)
+                infoManager.updateInfoData(type: .smoothedBg, value: Localizer.toDisplayUnits(String(smoothedBgValue)))
+            }
+
             // Eventual BG
             if let eventualBGValue = enactedOrSuggested["eventualBG"] as? Double {
                 let eventualBGQuantity = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: eventualBGValue)

--- a/LoopFollow/Controllers/Nightscout/SmoothedBgHistory.swift
+++ b/LoopFollow/Controllers/Nightscout/SmoothedBgHistory.swift
@@ -1,0 +1,156 @@
+// LoopFollow
+// SmoothedBgHistory.swift
+
+import Foundation
+
+struct SmoothedBgPoint {
+    let time: TimeInterval
+    let bgMgdl: Double
+}
+
+/// Decodable view of a single Nightscout devicestatus record, narrowed to just the
+/// fields needed to extract OpenAPS/Trio's smoothed BG. Unrecognized JSON keys are
+/// ignored by JSONDecoder, so the full devicestatus payload is parsed cheaply —
+/// no nested predictions / IOB / COB tree is materialized.
+private struct DeviceStatusBgRecord: Decodable {
+    let created_at: String?
+    let openaps: OpenAPSBlock?
+
+    struct OpenAPSBlock: Decodable {
+        let suggested: BgInner?
+        let enacted: BgInner?
+    }
+
+    struct BgInner: Decodable {
+        let bg: Double?
+        let timestamp: String?
+    }
+
+    func point(formatter: ISO8601DateFormatter) -> SmoothedBgPoint? {
+        let inner = openaps?.suggested ?? openaps?.enacted
+        guard let bg = inner?.bg else { return nil }
+
+        let raw = inner?.timestamp ?? created_at
+        guard let ts = raw, let t = formatter.date(from: ts)?.timeIntervalSince1970 else { return nil }
+        return SmoothedBgPoint(time: t, bgMgdl: bg)
+    }
+}
+
+extension MainViewController {
+    /// Fetches OpenAPS/Trio devicestatus records over the configured graph range and
+    /// extracts each loop run's smoothed BG, so the chart-tap popup can show the
+    /// smoothed value next to every glucose dot. Mirrors the BG-data fetch path:
+    /// typed `Decodable` + `count` + `find[date][$gte]` + `executeRequest`.
+    func webLoadNSSmoothedBgHistory() {
+        guard Storage.shared.displaySmoothedBG.value else { return }
+        guard IsNightscoutEnabled() else { return }
+
+        // Mark as fetched up-front so the gating check in DeviceStatus.swift doesn't
+        // re-enter while this request is in flight. Reset on failure below.
+        hasFetchedSmoothedBgHistory = true
+        lastSmoothedBgBulkRefreshAt = Date()
+
+        let days = max(1, Storage.shared.downloadDays.value)
+        let count = days * 24 * 12 + 24
+        let startMs = Int(Date().addingTimeInterval(-Double(days) * 86400).timeIntervalSince1970 * 1000)
+
+        let parameters: [String: String] = [
+            "count": "\(count)",
+            "find[created_at][$gte]": "\(startMs)",
+        ]
+
+        NightscoutUtils.executeRequest(eventType: .deviceStatus, parameters: parameters) { [weak self] (result: Result<[DeviceStatusBgRecord], Error>) in
+            switch result {
+            case let .success(records):
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withFullDate, .withTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
+
+                var seen = Set<Int>()
+                var points: [SmoothedBgPoint] = []
+                points.reserveCapacity(records.count)
+                for record in records {
+                    guard let p = record.point(formatter: formatter) else { continue }
+                    // Dedup by integer-second to collapse near-duplicate enacted/suggested rows.
+                    if seen.insert(Int(p.time)).inserted {
+                        points.append(p)
+                    }
+                }
+
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    // Merge with anything appendSmoothedBgPoint added while the fetch was in flight.
+                    for existing in self.smoothedBgData {
+                        if seen.insert(Int(existing.time)).inserted {
+                            points.append(existing)
+                        }
+                    }
+                    points.sort { $0.time < $1.time }
+                    self.smoothedBgData = points
+                    self.updateBGGraph()
+                }
+
+            case let .failure(error):
+                LogManager.shared.log(category: .deviceStatus, message: "Smoothed BG history fetch failed: \(error.localizedDescription)", limitIdentifier: "Smoothed BG history fetch failed")
+                DispatchQueue.main.async {
+                    // Allow retry on the next devicestatus cycle.
+                    self?.hasFetchedSmoothedBgHistory = false
+                }
+            }
+        }
+    }
+
+    /// Merge a single freshly-parsed point into the in-memory history. Called after
+    /// each devicestatus refresh so the latest reading always has a match without a
+    /// new bulk fetch.
+    func appendSmoothedBgPoint(time: TimeInterval, bgMgdl: Double) {
+        guard Storage.shared.displaySmoothedBG.value else { return }
+        let key = Int(time)
+        if smoothedBgData.contains(where: { Int($0.time) == key }) { return }
+
+        let previousLatestTime = smoothedBgData.last?.time
+        smoothedBgData.append(SmoothedBgPoint(time: time, bgMgdl: bgMgdl))
+        smoothedBgData.sort { $0.time < $1.time }
+
+        // Drop entries older than the configured graph range to bound memory.
+        let cutoff = Date().timeIntervalSince1970 - Double(max(1, Storage.shared.downloadDays.value)) * 86400
+        if let firstKept = smoothedBgData.firstIndex(where: { $0.time >= cutoff }), firstKept > 0 {
+            smoothedBgData.removeFirst(firstKept)
+        }
+
+        // Refresh the chart so the dot for this loop run picks up the smoothed
+        // value immediately — without waiting for the next BG fetch cycle.
+        updateBGGraph()
+
+        // Gap detection: if the new point is far ahead of the previous latest,
+        // we likely missed loop runs (Trio offline, network glitch, etc.). Trigger
+        // a debounced bulk refresh so older dots can backfill their smoothed values
+        // without needing a force-close + reopen.
+        if let prev = previousLatestTime, time - prev > 360 {
+            considerSmoothedBgGapRefresh()
+        }
+    }
+
+    private func considerSmoothedBgGapRefresh() {
+        let lastAge = lastSmoothedBgBulkRefreshAt.map { -$0.timeIntervalSinceNow } ?? .infinity
+        guard lastAge >= 120 else { return } // debounce: max once per 2 min
+        hasFetchedSmoothedBgHistory = false
+        webLoadNSSmoothedBgHistory()
+    }
+
+    /// Look up the smoothed BG closest to the given timestamp. Returns nil if no
+    /// recorded loop run is within the tolerance window.
+    func smoothedBg(near time: TimeInterval, tolerance: TimeInterval = 150) -> Double? {
+        guard !smoothedBgData.isEmpty else { return nil }
+        var best: SmoothedBgPoint?
+        var bestDiff = tolerance
+        for p in smoothedBgData {
+            let diff = abs(p.time - time)
+            if diff <= bestDiff {
+                best = p
+                bestDiff = diff
+            }
+            if p.time - time > tolerance { break }
+        }
+        return best?.bgMgdl
+    }
+}

--- a/LoopFollow/InfoTable/InfoType.swift
+++ b/LoopFollow/InfoTable/InfoType.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 enum InfoType: Int, CaseIterable {
-    case iob, cob, basal, override, battery, pump, pumpBattery, sage, cage, recBolus, minMax, carbsToday, autosens, profile, target, isf, carbRatio, updated, tdd, iage
+    case iob, cob, basal, override, battery, pump, pumpBattery, sage, cage, recBolus, minMax, carbsToday, autosens, profile, target, isf, carbRatio, updated, tdd, iage, smoothedBg
 
     var name: String {
         switch self {
@@ -28,6 +28,7 @@ enum InfoType: Int, CaseIterable {
         case .updated: return "Updated"
         case .tdd: return "TDD"
         case .iage: return "IAGE"
+        case .smoothedBg: return "Smoothed BG"
         }
     }
 

--- a/LoopFollow/Settings/AdvancedSettingsView.swift
+++ b/LoopFollow/Settings/AdvancedSettingsView.swift
@@ -20,6 +20,8 @@ struct AdvancedSettingsView: View {
                     Stepper(value: $viewModel.bgUpdateDelay, in: 1 ... 30, step: 1) {
                         Text("BG Update Delay (Sec): \(viewModel.bgUpdateDelay)")
                     }
+
+                    Toggle("Display Smoothed BG", isOn: $viewModel.displaySmoothedBG)
                 }
 
                 Section(header: Text("Logging Options")) {

--- a/LoopFollow/Settings/AdvancedSettingsViewModel.swift
+++ b/LoopFollow/Settings/AdvancedSettingsViewModel.swift
@@ -46,6 +46,12 @@ class AdvancedSettingsViewModel: ObservableObject {
         }
     }
 
+    @Published var displaySmoothedBG: Bool {
+        didSet {
+            Storage.shared.displaySmoothedBG.value = displaySmoothedBG
+        }
+    }
+
     @Published var debugLogLevel: Bool {
         didSet {
             Storage.shared.debugLogLevel.value = debugLogLevel
@@ -60,6 +66,7 @@ class AdvancedSettingsViewModel: ObservableObject {
         graphCarbs = Storage.shared.graphCarbs.value
         graphOtherTreatments = Storage.shared.graphOtherTreatments.value
         bgUpdateDelay = Storage.shared.bgUpdateDelay.value
+        displaySmoothedBG = Storage.shared.displaySmoothedBG.value
         debugLogLevel = Storage.shared.debugLogLevel.value
     }
 }

--- a/LoopFollow/Settings/GraphSettingsView.swift
+++ b/LoopFollow/Settings/GraphSettingsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct GraphSettingsView: View {
     @ObservedObject private var showDots = Storage.shared.showDots
     @ObservedObject private var showLines = Storage.shared.showLines
+    @ObservedObject private var displaySmoothedBG = Storage.shared.displaySmoothedBG
     @ObservedObject private var showValues = Storage.shared.showValues
     @ObservedObject private var showAbsorption = Storage.shared.showAbsorption
     @ObservedObject private var showDIALines = Storage.shared.showDIALines
@@ -27,12 +28,16 @@ struct GraphSettingsView: View {
         NavigationView {
             Form {
                 // ── Graph Display ────────────────────────────────────────────
-                Section("Graph Display") {
+                Section(header: Text("Graph Display"), footer: smoothingFooter) {
                     Toggle("Display Dots", isOn: $showDots.value)
                         .onChange(of: showDots.value) { _ in markDirty() }
+                        .disabled(displaySmoothedBG.value)
+                        .foregroundColor(displaySmoothedBG.value ? .secondary : .primary)
 
                     Toggle("Display Lines", isOn: $showLines.value)
                         .onChange(of: showLines.value) { _ in markDirty() }
+                        .disabled(displaySmoothedBG.value)
+                        .foregroundColor(displaySmoothedBG.value ? .secondary : .primary)
 
                     if nightscoutEnabled {
                         Toggle("Show DIA Lines", isOn: $showDIALines.value)
@@ -134,5 +139,14 @@ struct GraphSettingsView: View {
     /// Marks the chart as needing a redraw
     private func markDirty() {
         Observable.shared.chartSettingsChanged.value = true
+    }
+
+    @ViewBuilder
+    private var smoothingFooter: some View {
+        if displaySmoothedBG.value {
+            Text("Display Dots and Display Lines are managed automatically while Display Smoothed BG is on (CGM dots shown, white smoothing line replaces the connecting line).")
+        } else {
+            EmptyView()
+        }
     }
 }

--- a/LoopFollow/Storage/Storage.swift
+++ b/LoopFollow/Storage/Storage.swift
@@ -169,6 +169,7 @@ class Storage {
     var graphBolus = StorageValue<Bool>(key: "graphBolus", defaultValue: true)
     var graphCarbs = StorageValue<Bool>(key: "graphCarbs", defaultValue: true)
     var bgUpdateDelay = StorageValue<Int>(key: "bgUpdateDelay", defaultValue: 10)
+    var displaySmoothedBG = StorageValue<Bool>(key: "displaySmoothedBG", defaultValue: false)
 
     // MARK: - Insert times (sensor / pump) ---------------------------------------
 
@@ -387,6 +388,7 @@ class Storage {
         graphBolus.reload()
         graphCarbs.reload()
         bgUpdateDelay.reload()
+        displaySmoothedBG.reload()
 
         cageInsertTime.reload()
         sageInsertTime.reload()

--- a/LoopFollow/ViewControllers/MainViewController.swift
+++ b/LoopFollow/ViewControllers/MainViewController.swift
@@ -95,6 +95,9 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
     var predictionData: [ShareGlucoseData] = []
     var openAPSPredBGs: [String: [Double]]?
     var openAPSPredUpdatedTime: TimeInterval?
+    var smoothedBgData: [SmoothedBgPoint] = []
+    var hasFetchedSmoothedBgHistory: Bool = false
+    var lastSmoothedBgBulkRefreshAt: Date?
     var bgCheckData: [ShareGlucoseData] = []
     var suspendGraphData: [DataStructs.timestampOnlyStruct] = []
     var resumeGraphData: [DataStructs.timestampOnlyStruct] = []
@@ -274,6 +277,41 @@ class MainViewController: UIViewController, UITableViewDataSource, ChartViewDele
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateBGTextAppearance()
+            }
+            .store(in: &cancellables)
+
+        // Refetch the smoothed-BG history when the graph day-range setting changes,
+        // so the popup history covers the newly visible window. The fetch itself
+        // bails when the feature toggle is off, so this is cheap when unused.
+        Storage.shared.downloadDays.$value
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                guard Storage.shared.displaySmoothedBG.value else { return }
+                self.smoothedBgData = []
+                self.hasFetchedSmoothedBgHistory = false
+                self.webLoadNSSmoothedBgHistory()
+            }
+            .store(in: &cancellables)
+
+        // React to the smoothed-BG toggle: fetch on ON, drop the cached history on OFF
+        // and refresh the chart so popups stop showing smoothed values immediately.
+        Storage.shared.displaySmoothedBG.$value
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] enabled in
+                guard let self = self else { return }
+                if enabled {
+                    self.hasFetchedSmoothedBgHistory = false
+                    self.webLoadNSSmoothedBgHistory()
+                } else {
+                    self.smoothedBgData = []
+                    self.hasFetchedSmoothedBgHistory = false
+                    self.infoManager.clearInfoData(type: .smoothedBg)
+                    self.updateBGGraph()
+                }
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
- Adds Display Smoothed BG toggle in Settings → Advanced (off by default).
- Pulls smoothed values from Nightscout devicestatus openaps.enacted.bg / openaps.suggested.bg and stores an in-memory history bounded by the graph's day range.
- Renders smoothed values as a light-grey line on the main BG chart; CGM dots stay colorful, but the dot-connecting line is hidden while smoothing is on. Display Dots / Display Lines toggles are disabled in Graph Settings during this mode.
- Chart-tap popup shows the smoothed value (✨ … ✨) above the raw CGM value when a match is available within tolerance of the dot's timestamp.
- All work (fetches, parsing, polling) is gated on the toggle so users who don't enable it incur no extra overhead.
- Add the option for users to display the smoothed value in the information display table as well.