### PR TITLE
Restore graph value labels at 3h zoom after smoothing-line addition

### DIFF
--- a/LoopFollow/Controllers/Graphs.swift
+++ b/LoopFollow/Controllers/Graphs.swift
@@ -696,6 +696,14 @@ extension MainViewController {
         BGChart.drawGridBackgroundEnabled = true
         BGChart.gridBackgroundColor = NSUIColor.secondarySystemBackground
 
+        // Bumped from the library default of 100 to 150 so the bolus / carb / SMB
+        // value labels still render at the 3h zoom level after the smoothing-line
+        // dataset added ~280 entries to the chart's total entry count. DGCharts
+        // hides values when total-entries × scaleX exceeds maxVisibleCount × scaleX;
+        // 150 absorbs the new dataset while keeping ≥6h zooms hiding values, as
+        // before.
+        BGChart.maxVisibleCount = 150
+
         BGChart.highlightValue(nil, callDelegate: false)
 
         BGChart.data = data


### PR DESCRIPTION
- The Smoothed BG feature added a chart dataset that contributes ~280 entries per downloadDays day, pushing the chart's total data.entryCount from ~600 to ~880 with smoothing on (1-day default).
- DGCharts gates value-label rendering on data.entryCount < maxVisibleCount × scaleX. With the library default of 100, the 3h zoom (scaleX = 8, cap 800) no longer cleared the new total, so bolus / carb / SMB value labels stopped appearing at 3h.
- Set BGChart.maxVisibleCount = 150 so the threshold accommodates the extra entries while keeping ≥6h zooms hiding values, matching the prior behavior in both smoothing-on and smoothing-off states.