### PR TITLE
Fix stale/missing "TDD", "Smoothed BG", and "Updated" in info table

### DIFF
--- a/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatusOpenAPS.swift
@@ -12,17 +12,36 @@ extension MainViewController {
             LoopStatusLabel.text = "X"
             latestLoopStatusString = "X"
         } else {
-            guard let enactedOrSuggested = lastLoopRecord["suggested"] as? [String: AnyObject] ?? lastLoopRecord["enacted"] as? [String: AnyObject] else {
+            // Trio writes BOTH `suggested` (the current loop's recommendation:
+            // fresh bg / IOB / COB / ISF / CR / predBGs / reason / etc., but no
+            // timestamp or TDD) and `enacted` (the last actually-applied state:
+            // carries timestamp and TDD, but may linger at a previous loop's
+            // values if the new loop didn't change anything). We merge and prefer
+            // suggested on conflicts so each field reflects the latest loop's
+            // view, then fall back to enacted for fields suggested doesn't have.
+            let suggestedBlock = lastLoopRecord["suggested"] as? [String: AnyObject] ?? [:]
+            let enactedBlock = lastLoopRecord["enacted"] as? [String: AnyObject] ?? [:]
+            guard !suggestedBlock.isEmpty || !enactedBlock.isEmpty else {
                 LoopStatusLabel.text = "↻"
                 latestLoopStatusString = "↻"
                 return
             }
+            let enactedOrSuggested = enactedBlock.merging(suggestedBlock) { _, suggestedValue in suggestedValue }
 
             var updatedTime: TimeInterval?
 
-            if let timestamp = enactedOrSuggested["timestamp"] as? String,
-               let parsedTime = formatter.date(from: timestamp)?.timeIntervalSince1970
+            // For "Updated", prefer suggested.timestamp (latest loop's time), then
+            // the record's outer created_at (when NS received the upload — also
+            // ~latest loop's time), then enacted.timestamp (may be stale). We use
+            // NightscoutUtils.parseDate instead of ISO8601DateFormatter so we
+            // tolerate the trailing "Z" and fractional seconds NS often emits.
+            let timestampSource = (suggestedBlock["timestamp"] as? String)
+                ?? (lastDeviceStatus?["created_at"] as? String)
+                ?? (enactedBlock["timestamp"] as? String)
+            if let ts = timestampSource,
+               let parsedDate = NightscoutUtils.parseDate(ts)
             {
+                let parsedTime = parsedDate.timeIntervalSince1970
                 updatedTime = parsedTime
                 let formattedTime = Localizer.formatTimestampToLocalString(parsedTime)
                 infoManager.updateInfoData(type: .updated, value: formattedTime)


### PR DESCRIPTION
- Bug: Updated, TDD, and Smoothed BG rows showed blank or stale values.
- Cause: parser picked just one of openaps.suggested / openaps.enacted (preferred suggested via ??), but Trio splits each loop's data across both blocks. suggested has fresh bg / IOB / COB / ISF / CR but no timestamp or TDD; enacted has timestamp and TDD but can linger at a previous loop's values.
- Fix: merge both blocks with suggested winning on conflicts (latest loop's values), fall back to the record's outer created_at for the Updated timestamp, and switch to NightscoutUtils.parseDate so trailing Z / fractional seconds parse cleanly.